### PR TITLE
Changed the loading of the data files.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,12 @@
+import gencUrl from './src/main/ts/armyc2/c5isr/data/genc.json';
+import msdUrl from './src/main/ts/armyc2/c5isr/data/msd.json';
+import mseUrl from './src/main/ts/armyc2/c5isr/data/mse.json';
+import svgdUrl from './src/main/ts/armyc2/c5isr/data/svgd.json';
+import svgeUrl from './src/main/ts/armyc2/c5isr/data/svge.json';
+
+if(gencUrl && msdUrl && mseUrl && svgdUrl && svgeUrl)
+  console.log("data files located");
+
 import { ErrorLogger } from "./src/main/ts/armyc2/c5isr/renderer/utilities/ErrorLogger";
 import { GENCLookup } from "./src/main/ts/armyc2/c5isr/renderer/utilities/GENCLookup";
 import { MSLookup } from "./src/main/ts/armyc2/c5isr/renderer/utilities/MSLookup";
@@ -51,6 +60,7 @@ let initializing:boolean = false;
  * pass in "/dist/".  This is needed when all the files aren't in the same location.  When the renderer gets imported, it thinks it's 
  * in the location of the file that imported it, not where it actually exists and then it can't find the asset files.  If location is not
  * set, the renderer assumes the json asset files are in the same location as where the C5Ren script is being run.
+ * Additionally, if your build process hashes the manifest.json file, you should include the new name like "/dist/manifest.[hash].json"
  */
 export async function initialize(location?:string):Promise<any>
 {
@@ -60,11 +70,43 @@ export async function initialize(location?:string):Promise<any>
     if(!initialized)
     {
       let promises:Array<Promise<any>> = new Array<Promise<any>>()
-      if(location && location.startsWith('/')==false)
-        location = '/' + location;
-      promises.push(GENCLookup.loadData(location));
-      promises.push(MSLookup.loadData(location));
-      promises.push(SVGLookup.loadData(location));
+      let manifestName:string = 'manifest.json';
+      let manifestIndex:number = -1;
+
+      //Load data from specific path
+      let path:string = "";
+      if(location)
+      {
+        if(location.startsWith('/')==false)
+          location = '/' + location;
+        manifestIndex = location.indexOf("manifest");
+        if(location.endsWith("json") && manifestIndex >= 0)
+        {
+          manifestName = location.substring(manifestIndex);
+          location = location.substring(0,manifestIndex);
+        }
+        if(location.endsWith('/')==true)
+          location = location.substring(0,location.length-1);
+        path = location;
+      }
+        
+
+      //load data from path provided in manifest file/////////////////////
+      // Fetch Webpack manifest to get the hashed filename
+      const manifestResponse = await fetch(location + "/" + manifestName);
+      const manifest = await manifestResponse.json();
+
+      // Get the hashed JSON file URL
+      const gencUrl = path + manifest['data/genc.json'];
+      const msdUrl = path + manifest['data/msd.json'];
+      const mseUrl = path + manifest['data/mse.json'];
+      const svgdUrl = path + manifest['data/svgd.json'];
+      const svgeUrl = path + manifest['data/svge.json'];
+
+      promises.push(GENCLookup.setData(gencUrl));
+      promises.push(MSLookup.setData([msdUrl,mseUrl]));
+      promises.push(SVGLookup.setData([svgdUrl,svgeUrl]));
+
       await Promise.all(promises).then(values => {GENCLookup.getInstance();MSLookup.getInstance();SVGLookup.getInstance()}).catch(error => {throw error;});
       initialized=true;
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MIL-STD-2525 D/E symbol rendering TypeScript library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "resolveJsonModule": false,
+  "resolveJsonModule": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rd /S /Q dist",
@@ -29,11 +29,13 @@
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",
     "dts-bundle-generator": "^9.5.1",
+    "file-loader": "^6.2.0",
     "jszip": "^3.10.1",
     "ts-loader": "^9.5.1",
     "tslib": "^2.6.3",
     "typedoc": "^0.26.3",
     "webpack": "^5.92.1",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "webpack-manifest-plugin": "^5.0.1"
   }
 }

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/GENCLookup.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/GENCLookup.ts
@@ -17,7 +17,7 @@ export class GENCLookup {
     private static genc:any;
 
 
-    public static async loadData(location?:string)
+    /*public static async loadData(location?:string)
     {
         let path:string = GENCLookup.gencJSON;//String(genc);
         if(location)
@@ -26,6 +26,11 @@ export class GENCLookup {
         }
         RendererUtilities.getData(path).then(result => {this.genc = result;}).catch((err) => {ErrorLogger.LogException("GENCLookup","loadData",err)});
         //RendererUtilities.getData(String(genc)).then(result => {this.genc = result;});
+    }//*/
+
+    public static async setData(url:string)
+    {
+        RendererUtilities.getData(url).then(result => {this.genc = result;}).catch((err) => {ErrorLogger.LogException("GENCLookup","loadData",err)});
     }
 
     private constructor() 

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/MSLookup.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/MSLookup.ts
@@ -25,7 +25,7 @@ export class MSLookup {
     private static msdJSON:string = "/msd.json";
     private static mseJSON:string = "/mse.json";
 
-    public static async loadData(location?:string)
+    /*public static async loadData(location?:string)
     {
         let pathd:string = MSLookup.msdJSON;//String(msdj);
         let pathe:string = MSLookup.mseJSON;//String(msej);
@@ -39,12 +39,21 @@ export class MSLookup {
         
         promises.push(RendererUtilities.getData(pathd));
         promises.push(RendererUtilities.getData(pathe));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
-        await Promise.all(promises).then(values => {MSLookup.msd = values[0];MSLookup.mse = values[1];}).catch(error => {throw error;})//*/
+        await Promise.all(promises).then(values => {MSLookup.msd = values[0];MSLookup.mse = values[1];}).catch(error => {throw error;})
 
-        /*let promises:Array<Promise<any>> = new Array<Promise<any>>()
+        //let promises:Array<Promise<any>> = new Array<Promise<any>>()
         
-        promises.push(RendererUtilities.getData(String(msdj)));
-        promises.push(RendererUtilities.getData(String(msej)));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
+        //promises.push(RendererUtilities.getData(String(msdj)));
+        //promises.push(RendererUtilities.getData(String(msej)));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
+        //await Promise.all(promises).then(values => {MSLookup.msd = values[0];MSLookup.mse = values[1];}).catch(error => {throw error;})
+    }//*/
+
+    public static async setData(urls:string[])
+    {
+        let promises:Array<Promise<any>> = new Array<Promise<any>>();
+
+        promises.push(RendererUtilities.getData(urls[0]));
+        promises.push(RendererUtilities.getData(urls[1]));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
         await Promise.all(promises).then(values => {MSLookup.msd = values[0];MSLookup.mse = values[1];}).catch(error => {throw error;})//*/
     }
     /*

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SVGLookup.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SVGLookup.ts
@@ -20,7 +20,7 @@ export class SVGLookup
     private static svgdJSON:string = "/svgd.json";
     private static svgeJSON:string = "/svge.json";
 
-    public static async loadData(location?:string)
+    /*public static async loadData(location?:string)
     {
 
         let pathd:string = SVGLookup.svgdJSON;//String(svgdj);
@@ -37,11 +37,20 @@ export class SVGLookup
         promises.push(RendererUtilities.getData(pathe));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
         await Promise.all(promises).then(values => {SVGLookup.svgd = values[0];SVGLookup.svge = values[1];}).catch(error => {throw error;})
 
-        /*let promises:Array<Promise<any>> = new Array<Promise<any>>()
+        //let promises:Array<Promise<any>> = new Array<Promise<any>>()
         
-        promises.push(RendererUtilities.getData(String(svgdj)));
-        promises.push(RendererUtilities.getData(String(svgej)));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
-        await Promise.all(promises).then(values => {SVGLookup.svgd = values[0];SVGLookup.svge = values[1];}).catch(error => {throw error;})//*/
+        //promises.push(RendererUtilities.getData(String(svgdj)));
+        //promises.push(RendererUtilities.getData(String(svgej)));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
+        //await Promise.all(promises).then(values => {SVGLookup.svgd = values[0];SVGLookup.svge = values[1];}).catch(error => {throw error;})
+    }//*/
+
+    public static async setData(urls:string[])
+    {
+        let promises:Array<Promise<any>> = new Array<Promise<any>>();
+
+        promises.push(RendererUtilities.getData(urls[0]));
+        promises.push(RendererUtilities.getData(urls[1]));// RendererUtilities.getData(String(svgd)).then(function(result){this.genc = result;this.init();});
+        await Promise.all(promises).then(values => {SVGLookup.svgd = values[0];SVGLookup.svge = values[1];}).catch(error => {throw error;})
     }
 
     private constructor() {

--- a/test/singlePointTester3.html
+++ b/test/singlePointTester3.html
@@ -531,8 +531,12 @@
     function setup()
     {
         document.getElementById("btnST1").disabled = true; 
+        //Assumes location page is running in
         //C5Ren.initialize().then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});
-        C5Ren.initialize('/dist/').then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});
+        //Set location where renderer and files are
+        //C5Ren.initialize('/dist/').then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});
+        //Tell the renderer specficially where the manifest file is in case the users process renamed it with a hash or something.
+        C5Ren.initialize('/dist/manifest.json').then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});
 
         /*if(C5Ren.isReady())
         {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "resolveJsonModule": false,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "target": "es2022",
     "lib": [

--- a/webpackr.config.js
+++ b/webpackr.config.js
@@ -1,4 +1,5 @@
 const CopyPlugin = require("copy-webpack-plugin");
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const path = require('path');
 module.exports = {
    entry: './dist/index.js',
@@ -9,26 +10,38 @@ module.exports = {
    output: {
       filename: 'C5Ren.js',
       path: path.resolve(__dirname, 'dist'),
+      publicPath: '/',
       library: 'C5Ren',
       libraryTarget: 'umd',     
    },
    resolve: {
       extensions: ['.ts', '.js'],
    },
+   plugins: [
+      new WebpackManifestPlugin({
+        fileName: 'manifest.json',
+      })],
    module: {
       rules: [
+         {
+            test: /\.json$/,
+            type: 'asset/resource',
+            generator: {
+               filename: 'data/[name].[contenthash][ext]' // Stores JSON separately in 'data/' folder
+            }
+         },
          {
             test: /\.ts$/,
             use: 'ts-loader',
             exclude: /node_modules/,
-         },
+         }
       ],
    }, 
-   plugins: [
+   /*plugins: [
       new CopyPlugin({
         patterns: [
           { from: "./src/main/ts/armyc2/c5isr/data/*", to: "[name][ext]" }
         ],
       }),
-    ],
+    ],//*/
 };


### PR DESCRIPTION
The files get hashsed now.  There's a manifest file that provides the hashed name given the base name. C5Ren.initialize generally works the same if it was working fine for you before.  If your process hashes the manifest file, you can pass the path to the manifest including its new name so the resources can be loaded. See the updated setup function in SinglePointTester3.html

```
//Assumes location page is running in
//C5Ren.initialize().then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});  

//Set location where renderer and files are
//C5Ren.initialize('/dist/').then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});  

//Tell the renderer specficially where the manifest file is in case the users process renamed it with a hash or something.
C5Ren.initialize('/dist/manifest.[hash].json').then(function(results){document.getElementById("btnST1").disabled = false;preload();}).catch(error => {throw error;});
```