### PR TITLE
Basic shapes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,6 +36,8 @@ export { SymbolID } from "./src/main/ts/armyc2/c5isr/renderer/utilities/SymbolID
 export { ShapeInfo } from "./src/main/ts/armyc2/c5isr/renderer/utilities/ShapeInfo";
 export { MilStdSymbol } from "./src/main/ts/armyc2/c5isr/renderer/utilities/MilStdSymbol";
 
+export { BasicShapes } from "./src/main/ts/armyc2/c5isr/JavaLineArray/BasicShapes"
+
 export type { IPointConversion } from "./src/main/ts/armyc2/c5isr/renderer/utilities/IPointConversion";
 export { PointConverter3D } from "./src/main/ts/armyc2/c5isr/renderer/utilities/PointConverter3D";
 export { clsRenderer } from "./src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer";

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/BasicShapes.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/BasicShapes.ts
@@ -1,0 +1,99 @@
+import { TacticalLines } from "./TacticalLines";
+import { DrawRules } from "../renderer/utilities/DrawRules";
+
+export class BasicShapes {
+    /**
+     * Anchor Points: This symbol requires at least two anchor points, points 1
+     * and 2, to define the line. Additional points can be defined to extend the
+     * line.
+     * <p>
+     * Size/Shape: The first and last anchor points determine the length of the
+     * line.
+     * <p>
+     * Orientation: Orientation is determined by the order in which the anchor points are entered.
+     * <p>
+     * Modifiers: T
+     *
+     * @see DrawRules.LINE1
+     */
+    public static readonly LINE = TacticalLines.BS_LINE;
+
+    /**
+     * Anchor Points: This symbol requires at least three anchor points to
+     * define the boundary of the area. Add as many points as necessary to
+     * accurately reflect the area’s size and shape.
+     * <p>
+     * Size/Shape: Determined by the anchor points. The information fields
+     * should be moveable and scalable as a block within the area.
+     * <p>
+     * Modifiers: T
+     *
+     * @see DrawRules.AREA1
+     */
+    public static readonly AREA = TacticalLines.BS_AREA;
+
+    /**
+     * Anchor Points: This symbol requires one anchor point. This anchor point
+     * represents the center of an ellipse and, therefore, the geographic
+     * location of that ellipse.
+     * <p>
+     * Size/Shape: The size and shape of this symbol is determined by three
+     * additional numeric values; A major axis radius, a minor axis radius, and
+     * a rotation angle. The radii should be expressed in the appropriate map
+     * distance units.
+     * <p>
+     * Orientation: The orientation of this symbol is determined by the rotation
+     * angle provided, where 0 degrees is east/west and a positive rotation
+     * angle rotates the ellipse in a counter-clockwise direction.
+     * <p>
+     * Modifiers: AM, AN, T
+     *
+     * @see DrawRules.ELLIPSE1
+     */
+    public static readonly ELLIPSE = TacticalLines.PBS_ELLIPSE;
+
+    /**
+     * Anchor Points: This symbol requires one (1) anchor point and a radius.
+     * Point 1 defines the center point of the symbol.
+     * <p>
+     * Size/Shape: Size: The radius defines the size.
+     * <p>
+     * Orientation: Not applicable
+     * <p>
+     * Modifiers: AM, T
+     *
+     * @see DrawRules.CIRCULAR1
+     */
+    public static readonly CIRCLE = TacticalLines.PBS_CIRCLE;
+
+    /**
+     * Anchor Points: This symbol requires one (1) anchor point to define the
+     * center of the area.
+     * <p>
+     * Size/Shape: Size is determined by the anchor point, the length (in meters)
+     * and width (in meters).
+     * <p>
+     * Orientation: The orientation of this symbol is determined by the rotation
+     * angle provided, where 0 degrees is east/west and a positive rotation
+     * angle rotates the ellipse in a clockwise direction.
+     * <p>
+     * Modifiers: AM, AN, T
+     *
+     * @see DrawRules.RECTANGULAR2
+     */
+    public static readonly RECTANGLE = TacticalLines.PBS_RECTANGLE;
+
+    /**
+     * Anchor Points: This symbol requires one anchor point. The center point
+     * defines/is the center of the symbol.
+     * <p>
+     * Size/Shape: Line width defines the size of the point. The radius defines the size of the outline.
+     * <p>
+     * Orientation: Not applicable
+     * <p>
+     * Modifiers: AM, T
+     *
+     * @see DrawRules.POINT2
+     */
+    public static readonly POINT = TacticalLines.BBS_POINT;
+}

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/CELineArray.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/CELineArray.ts
@@ -148,6 +148,7 @@ export class CELineArray {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/Channels.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/Channels.ts
@@ -785,6 +785,11 @@ export class Channels {
                     break;
                 }
 
+                case TacticalLines.BBS_LINE: {
+                    lTotal = 2 * vblCounter + 1;
+                    break;
+                }
+
                 default: {
                     lTotal = 2 * vblCounter;
                     break;
@@ -1050,6 +1055,7 @@ export class Channels {
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.UNSP:
@@ -1525,7 +1531,7 @@ export class Channels {
             //end declarations
 
             //initializations
-            if (vblChannelWidth < 5) {
+            if (vblChannelWidth < 5 && vbiDrawThis != TacticalLines.BBS_LINE) {
                 vblChannelWidth = 5;
             }
 
@@ -1629,6 +1635,7 @@ export class Channels {
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.UNSP:
                 case TacticalLines.DOUBLEA:
@@ -1653,6 +1660,7 @@ export class Channels {
                         case TacticalLines.DOUBLEC:
                         case TacticalLines.SINGLEC:
                         case TacticalLines.HWFENCE:
+                        case TacticalLines.BBS_LINE:
                         case TacticalLines.LWFENCE:
                         case TacticalLines.UNSP:
                         case TacticalLines.DOUBLEA:
@@ -2035,7 +2043,8 @@ export class Channels {
                     lEllipseCounter = vblLowerCounter + vblUpperCounter;
                     //following section only for lines with repeating features, e.g. DOUBLEA
                     //if(segments!=null &&
-                    if (vbiDrawThis !== TacticalLines.CHANNEL &&
+                    if (vbiDrawThis != TacticalLines.BBS_LINE &&
+                        vbiDrawThis !== TacticalLines.CHANNEL &&
                         vbiDrawThis !== TacticalLines.CHANNEL_DASHED &&
                         vbiDrawThis !== TacticalLines.CHANNEL_FLARED &&
                         vbiDrawThis !== TacticalLines.SPT_STRAIGHT &&
@@ -2211,6 +2220,16 @@ export class Channels {
                             }
                         }
                     }
+                    break;
+                }
+
+                case TacticalLines.BBS_LINE: {
+                    pLinePoints = new POINT2[vblLowerCounter + vblUpperCounter + 1];
+                    for (j = 0; j < vblLowerCounter; j++)
+                        pLinePoints[j] = pLowerLinePoints[j];
+                    for (j = 0; j < vblUpperCounter; j++)
+                        pLinePoints[j + vblLowerCounter] = pUpperLinePoints[vblUpperCounter - 1 - j];
+                    pLinePoints[pLinePoints.length - 1] = pLinePoints[0];
                     break;
                 }
 
@@ -2740,6 +2759,17 @@ export class Channels {
                 shapes.unshift(...fillShapes); // shapes.addAll(0,fillShapes);
             }
 
+            //diagnostic
+            if(vbiDrawThis==TacticalLines.BBS_LINE)
+            {
+                //shapes.remove(1);
+                shape=new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                shape.moveTo(pOriginalLinePoints[0]);
+                for(j=1;j<pOriginalLinePoints.length;j++)
+                    shape.lineTo(pOriginalLinePoints[j]);
+                shapes.push(shape);
+            }
+            //end section
 
             lResult = lResultCounter;
             //FillPoints(pLinePoints,pLinePoints.length);
@@ -2768,6 +2798,17 @@ export class Channels {
             let n: int = pLinePoints.length;
             let t: int = 0;
             switch (lineType) {
+                case TacticalLines.BBS_LINE: {
+                    shape=new Shape2(Shape2.SHAPE_TYPE_FILL);
+                    shape.moveTo(pLinePoints[0]);
+                    //for(j=1;j<pLinePoints.length;j++)
+                    for(j=1;j<n;j++)
+                    {
+                        shape.lineTo(pLinePoints[j]);
+                    }
+                    break;
+                }
+
                 case TacticalLines.CHANNEL:
                 case TacticalLines.CHANNEL_FLARED:
                 case TacticalLines.CHANNEL_DASHED: {

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -2,7 +2,46 @@
  * Class to provide the symbols with values corresponding to the Mil-Standard-2525 hierarchy.
  *
  */
-export class TacticalLines  {
+export class TacticalLines {
+    public static readonly BS_LINE = 10000000;
+    public static readonly BS_AREA = 11000000;
+    /**
+     * @deprecated
+     */
+    public static readonly BS_CROSS = 12000000;
+    /**
+     * @deprecated
+     */
+    public static readonly BS_ELLIPSE = 13000000;
+    public static readonly PBS_ELLIPSE = 13000001;
+    public static readonly PBS_CIRCLE = 13000002;
+    /**
+     * @deprecated
+     */
+    public static readonly BS_RECTANGLE = 14000000;
+    public static readonly PBS_RECTANGLE = 14000001;
+    /**
+     * @deprecated
+     */
+    public static readonly PBS_SQUARE = 14000002;
+    /**
+     * @deprecated
+     */
+    public static readonly BBS_LINE = 15000000;
+    /**
+     * @deprecated
+     */
+    public static readonly BBS_AREA = 15000001;
+    public static readonly BBS_POINT = 15000002;
+    /**
+     * @deprecated
+     */
+    public static readonly BBS_RECTANGLE = 15000003;
+    /**
+     * @deprecated
+     */
+    public static readonly BS_BBOX = 15000004;
+
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;
     public static readonly DZ: number = 22135000;

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/arraysupport.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/arraysupport.ts
@@ -2329,6 +2329,91 @@ export class arraysupport {
             //resize the array and get the line array
             //for the specified non-channel line type
             switch (lineType) {
+                case TacticalLines.BBS_AREA: {
+                    lineutility.getExteriorPoints(pLinePoints, vblSaveCounter, lineType, false);
+                    acCounter = vblSaveCounter;
+                    break;
+                }
+                
+                case TacticalLines.BS_CROSS: {
+                    pt0 = new POINT2(pLinePoints[0]);
+                    pLinePoints[0] = new POINT2(pt0);
+                    pLinePoints[0].x -= 10;
+                    pLinePoints[1] = new POINT2(pt0);
+                    pLinePoints[1].x += 10;
+                    pLinePoints[1].style = 10;
+                    pLinePoints[2] = new POINT2(pt0);
+                    pLinePoints[2].y += 10;
+                    pLinePoints[3] = new POINT2(pt0);
+                    pLinePoints[3].y -= 10;
+                    acCounter = 4;
+                    break;
+                }  
+                
+                case TacticalLines.BS_RECTANGLE: {
+                    lineutility.CalcMBRPoints(pLinePoints, pLinePoints.length, pt0, pt2);   //pt0=ul, pt1=lr
+                    pt1 = new POINT2(pt0);
+                    pt1.x = pt2.x;
+                    pt3 = new POINT2(pt0);
+                    pt3.y = pt2.y;
+                    pLinePoints = new POINT2[5];
+                    pLinePoints[0] = new POINT2(pt0);
+                    pLinePoints[1] = new POINT2(pt1);
+                    pLinePoints[2] = new POINT2(pt2);
+                    pLinePoints[3] = new POINT2(pt3);
+                    pLinePoints[4] = new POINT2(pt0);
+                    acCounter = 5;
+                    break;
+                }
+                
+                case TacticalLines.BBS_RECTANGLE: {
+                    //double xmax=pLinePoints[0].x,xmin=pLinePoints[1].x,ymax=pLinePoints[0].y,ymin=pLinePoints[1].y;
+                    //double xmax=pLinePoints[2].x,xmin=pLinePoints[0].x,ymax=pLinePoints[2].y,ymin=pLinePoints[0].y;
+                    let buffer: double = pLinePoints[0].style;
+
+                    pOriginalLinePoints = new POINT2[5];
+                    pOriginalLinePoints[0] = new POINT2(pLinePoints[0]);
+                    pOriginalLinePoints[1] = new POINT2(pLinePoints[1]);
+                    pOriginalLinePoints[2] = new POINT2(pLinePoints[2]);
+                    pOriginalLinePoints[3] = new POINT2(pLinePoints[3]);
+                    pOriginalLinePoints[4] = new POINT2(pLinePoints[0]);
+
+                    //clockwise orientation
+                    pt0 = pLinePoints[0];
+                    pt0.x -= buffer;
+                    pt0.y -= buffer;
+                    pt1 = pLinePoints[1];
+                    pt1.x += buffer;
+                    pt1.y -= buffer;
+                    pt2 = pLinePoints[2];
+                    pt2.x += buffer;
+                    pt2.y += buffer;
+                    pt3 = pLinePoints[3];
+                    pt3.x -= buffer;
+                    pt3.y += buffer;
+                    pLinePoints = new POINT2[5];
+                    pLinePoints[0] = new POINT2(pt0);
+                    pLinePoints[1] = new POINT2(pt1);
+                    pLinePoints[2] = new POINT2(pt2);
+                    pLinePoints[3] = new POINT2(pt3);
+                    pLinePoints[4] = new POINT2(pt0);
+                    vblSaveCounter = 5;
+                    acCounter = 5;
+                    break;
+                }
+            
+                case TacticalLines.BS_ELLIPSE: {
+                    pt0 = pLinePoints[0];//the center of the ellipse
+                    pt1 = pLinePoints[1];//the width of the ellipse
+                    pt2 = pLinePoints[2];//the height of the ellipse
+                    //pLinePoints=getEllipsePoints(pt0,pt1,pt2);
+                    let azimuth: double = pLinePoints[3].x;
+                    pLinePoints = arraysupport.getRotatedEllipsePoints(pt0, pt1, pt2, azimuth, lineType);
+                    acCounter = 37;
+                    break;
+
+                }
+
                 case TacticalLines.OVERHEAD_WIRE: {
                     acCounter = arraysupport.getOverheadWire(tg, pLinePoints, vblSaveCounter);
                     break;
@@ -4296,6 +4381,8 @@ export class arraysupport {
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
                 case TacticalLines.SEIZE:
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BBS_RECTANGLE:
                 //add these
                 case TacticalLines.AIRFIELD:
                 case TacticalLines.CORDONKNOCK:
@@ -4366,6 +4453,25 @@ export class arraysupport {
                         secondPoly[i] = pLinePoints[i + 8];
                     }
                     arraysupport.addPolyline(secondPoly, 6, shapes);
+                    break;
+                }
+
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_RECTANGLE: {
+                    shape = new Shape2(Shape2.SHAPE_TYPE_FILL);
+                    shape.moveTo(pLinePoints[0]);
+                    for (j = 0; j < vblSaveCounter; j++) {
+                        shape.lineTo(pLinePoints[j]);
+                    }
+                    shapes.push(shape);
+
+                    shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                    shape.moveTo(pOriginalLinePoints[0]);
+                    for (j = 1; j < vblSaveCounter; j++) {
+                        shape.lineTo(pOriginalLinePoints[j]);
+                    }
+                    shapes.push(shape);
+
                     break;
                 }
 

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/countsupport.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/countsupport.ts
@@ -74,6 +74,16 @@ export class countsupport {
             lineutility.InitializePOINT2Array(pSquarePoints);
             //end delcarations
             switch (vbiDrawThis) {
+                case TacticalLines.BS_ELLIPSE: {
+                    count=37;
+                    break;
+                }
+
+                case TacticalLines.BS_CROSS: {
+                    count=4;
+                    break;
+                }
+
                 case TacticalLines.OVERHEAD_WIRE: {
                     count = vblCounter * 15;    //15 points per segment
                     break;
@@ -535,6 +545,11 @@ export class countsupport {
                 case TacticalLines.SFENCE:
                 case TacticalLines.DFENCE: {
                     count = Channels.GetTripleCountDouble(pLinePoints, vblCounter, vbiDrawThis);
+                    break;
+                }
+
+                case TacticalLines.BBS_LINE: {
+                    count = 2 * vblCounter;
                     break;
                 }
 

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/Modifier2.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/Modifier2.ts
@@ -2566,7 +2566,15 @@ export class Modifier2 {
                 case TacticalLines.CIRCULAR:
                 case TacticalLines.RECTANGULAR_TARGET:
                 case TacticalLines.LINE:
-                case TacticalLines.ASLTXING: {
+                case TacticalLines.ASLTXING:
+                case TacticalLines.BS_LINE:
+                case TacticalLines.BS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.PBS_ELLIPSE:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.BBS_POINT: {
                     origPoints = lineutility.getDeepCopy(tg.Pixels);
                     break;
                 }
@@ -2660,6 +2668,48 @@ export class Modifier2 {
                 case TacticalLines.PL: {
                     Modifier2.AddIntegralAreaModifier(tg, label + TSpace + tg.get_Name(), Modifier2.toEnd, T1LineFactor, pt0, pt1, false);
                     Modifier2.AddIntegralAreaModifier(tg, label + TSpace + tg.get_Name(), Modifier2.toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                    break;
+                }
+
+                case TacticalLines.BS_LINE:
+                case TacticalLines.BBS_LINE: {
+                    if (tg.get_T1() == null || tg.get_T1() == "") {
+                        Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.toEnd, T1LineFactor, pt0, pt1, false);
+                        Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                    } else {
+                        if (tg.get_T1() == "1") {
+                            for (j = 0; j < tg.Pixels.length - 1; j++) {
+                                Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.aboveMiddle, 0, tg.Pixels[j], tg.Pixels[j + 1], false);
+                            }
+                        } else if (tg.get_T1() == "2") {
+                            Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.toEnd, T1LineFactor, pt0, pt1, false);
+                            Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                        } else if (tg.get_T1() == "3") {
+                            //either end of the polyline
+                            dist = lineutility.CalcDistanceDouble(pt0, pt1);
+                            stringWidth = metrics.stringWidth(tg.get_Name());
+                            stringWidth /= 2;
+                            pt2 = lineutility.ExtendAlongLineDouble2(pt1, pt0, dist + stringWidth);
+                            Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.area, 0, pt2, pt2, false);
+                            dist = lineutility.CalcDistanceDouble(ptNextToLast, ptLast);
+                            pt2 = lineutility.ExtendAlongLineDouble2(ptNextToLast, ptLast, dist + stringWidth);
+                            Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.area, 0, pt2, pt2, false);
+                            //the intermediate points
+                            for (j = 1; j < tg.Pixels.length - 1; j++) {
+                                Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.area, 0, tg.Pixels[j], tg.Pixels[j], false);
+                            }
+                        } else //t1 is set inadvertantly or for other graphics
+                        {
+                            Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.toEnd, T1LineFactor, pt0, pt1, false);
+                            Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                        }
+                    }
+                    break;
+                }
+
+                case TacticalLines.BS_AREA:
+                case TacticalLines.BBS_AREA: {
+                    Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.area, 0, ptCenter, ptCenter, false);
                     break;
                 }
 
@@ -3061,6 +3111,14 @@ export class Modifier2 {
                 case TacticalLines.RECTANGULAR:
                 case TacticalLines.CIRCULAR: {
                     Modifier2.AddIntegralAreaModifier(tg, ap, Modifier2.area, 0, pt0, pt0, false);
+                    break;
+                }
+
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.PBS_ELLIPSE:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.BBS_POINT: {
+                    Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.area, 0, pt0, pt0, false);
                     break;
                 }
 
@@ -4053,6 +4111,8 @@ export class Modifier2 {
                 return;
             }
             switch (tg.get_LineType()) {
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BBS_RECTANGLE:
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                 case TacticalLines.BREACH:
@@ -4078,6 +4138,7 @@ export class Modifier2 {
                 case TacticalLines.CUED_ACQUISITION:
                 case TacticalLines.CIRCULAR:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.ATI_CIRCULAR:
@@ -4189,6 +4250,17 @@ export class Modifier2 {
 
             Modifier2.shiftModifierPath(tg, pt0, pt1, ptLast, ptNextToLast);
             switch (linetype) {
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BBS_RECTANGLE:{
+                    pts = new POINT2[4];
+                    for (j = 0; j < 4; j++) {
+                        pts[j] = tg.Pixels[j];
+                    }
+                    ptCenter = lineutility.CalcCenterPointDouble2(pts, 4);
+                    Modifier2.AddIntegralAreaModifier(tg, tg.get_Name(), Modifier2.area, -0.125 * csFactor, ptCenter, ptCenter, false);
+                    break;
+                }
+                
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY: {
                     pt2 = lineutility.MidPointDouble(tg.Pixels[0], tg.Pixels[3], 0);

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.ts
@@ -125,6 +125,7 @@ export class clsChannelUtility {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE: {
@@ -584,6 +585,17 @@ export class clsChannelUtility {
                     pixels2 = new Array<number>(pixels.length);
                     n = pixels.length;
                     //for (j = 0; j < pixels.length; j++) 
+                    for (j = 0; j < n; j++) {
+                        pixels2[j] = pixels[j];
+                    }
+                    break;
+                }
+
+                case TacticalLines.BBS_LINE: {
+                    channelWidth = 8 * tg.Pixels[0].style;  //was 20 1-10-13
+                    let pixels2: double[] = [];
+                    n = pixels.length;
+                    //for (j = 0; j < pixels.length; j++)
                     for (j = 0; j < n; j++) {
                         pixels2[j] = pixels[j];
                     }

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -141,6 +141,7 @@ export class clsUtility {
             case TacticalLines.RECTANGULAR:
             case TacticalLines.CUED_ACQUISITION:
             case TacticalLines.CIRCULAR:
+            case TacticalLines.PBS_CIRCLE:
             case TacticalLines.BDZ:
             case TacticalLines.FSA_CIRCULAR:
             case TacticalLines.NOTACK:
@@ -163,6 +164,7 @@ export class clsUtility {
             case TacticalLines.LAUNCH_AREA:
             case TacticalLines.DEFENDED_AREA_CIRCULAR:
             case TacticalLines.SHIP_AOI_CIRCULAR:
+            case TacticalLines.PBS_ELLIPSE:
             case TacticalLines.RANGE_FAN:
             case TacticalLines.RANGE_FAN_SECTOR:
             case TacticalLines.RADAR_SEARCH: {
@@ -371,6 +373,8 @@ export class clsUtility {
     public static isClosedPolygon(linetype: int): boolean {
         let result: boolean = false;
         switch (linetype) {
+            case TacticalLines.BBS_AREA:
+            case TacticalLines.BS_BBOX:
             case TacticalLines.AT:
             case TacticalLines.DEPICT:
             case TacticalLines.DZ:
@@ -399,6 +403,7 @@ export class clsUtility {
             case TacticalLines.JTAA:
             case TacticalLines.SAA:
             case TacticalLines.SGAA:
+            case TacticalLines.BS_AREA:
             case TacticalLines.ASSAULT:
             case TacticalLines.ATKPOS:
             case TacticalLines.OBJ:
@@ -759,7 +764,9 @@ export class clsUtility {
                             switch (lineType) {
                                 case TacticalLines.RANGE_FAN:
                                 case TacticalLines.RANGE_FAN_SECTOR:
-                                case TacticalLines.RADAR_SEARCH: {
+                                case TacticalLines.RADAR_SEARCH:
+                                case TacticalLines.BBS_AREA:
+                                case TacticalLines.BBS_RECTANGLE: {
                                     shape.setFillColor(null);
                                     break;
                                 }
@@ -770,6 +777,26 @@ export class clsUtility {
                                     break;
                                 }
 
+                            }
+                        }
+                        switch (lineType) {
+                            case TacticalLines.BS_ELLIPSE:
+                            case TacticalLines.BS_RECTANGLE: {
+                                //case TacticalLines.BBS_RECTANGLE:
+                                shape.setFillStyle(tg.get_FillStyle());
+                                shape.setFillColor(tg.get_FillColor());
+                                break;
+                            }
+
+                            case TacticalLines.BBS_RECTANGLE:
+                            case TacticalLines.PBS_RECTANGLE:
+                            case TacticalLines.PBS_SQUARE: {
+                                shape.setFillColor(null);
+                                break;
+                            }
+
+                            default: {
+                             break;
                             }
                         }
                     }
@@ -802,6 +829,7 @@ export class clsUtility {
         let result: boolean = false;
         try {
             switch (linetype) {
+                case TacticalLines.BS_LINE:
                 case TacticalLines.PAA_RECTANGULAR:
                 case TacticalLines.RECTANGULAR_TARGET:
                 case TacticalLines.CFL:
@@ -1140,6 +1168,12 @@ export class clsUtility {
 
                 }
 
+                //diagnostic
+                if(lineType==TacticalLines.BBS_POINT)
+                    if(j==0)
+                        shape.setLineColor(null);
+                //end section
+
 
                 shapeType = shape.getShapeType();
 
@@ -1208,10 +1242,15 @@ export class clsUtility {
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
                 case TacticalLines.SHIP_AOI_CIRCULAR:
+                case TacticalLines.PBS_ELLIPSE:
                 case TacticalLines.RECTANGULAR:
                 case TacticalLines.CUED_ACQUISITION:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
                 case TacticalLines.CIRCULAR:
+                case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.FFA_CIRCULAR:
@@ -1583,6 +1622,7 @@ export class clsUtility {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:
@@ -1995,6 +2035,17 @@ export class clsUtility {
      */
     public static isAutoshape(tg: TGLight): boolean {
         try {
+            switch(tg.get_LineType())
+            {
+                case TacticalLines.BBS_RECTANGLE:
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BS_ELLIPSE:
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.BS_CROSS:
+                case TacticalLines.BS_BBOX:
+                case TacticalLines.BBS_POINT:
+                    return true;
+            }
             let msInfo: MSInfo = MSLookup.getInstance().getMSLInfo(tg.get_SymbolId());
             if (msInfo == null || clsUtility.IsChange1Area(tg.get_LineType())) {
                 return false;
@@ -2406,6 +2457,7 @@ export class clsUtility {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -40,6 +40,7 @@ import { clsRenderer2 } from "../RenderMultipoints/clsRenderer2"
 import { clsUtility } from "../RenderMultipoints/clsUtility"
 import { clsUtilityCPOF } from "../RenderMultipoints/clsUtilityCPOF"
 import { clsUtilityGE } from "../RenderMultipoints/clsUtilityGE"
+import { BasicShapes } from "../JavaLineArray/BasicShapes";
 
 /**
  * Rendering class
@@ -105,6 +106,341 @@ export class clsRenderer {
             }
         }
         return coords;
+    }
+
+        /**
+     * Build a tactical graphic object from the client MilStdSymbol
+     *
+     * @param milStd MilstdSymbol object
+     * @param converter geographic to pixels converter
+     * @param lineType {@link BasicShapes}
+     * @return tactical graphic
+     */
+    public static createTGLightFromMilStdSymbolBasicShape(milStd: MilStdSymbol,
+                                                                converter: IPointConversion,
+                                                                   lineType: int): TGLight {
+        let tg: TGLight = new TGLight();
+        try {
+            let useLineInterpolation: boolean = milStd.getUseLineInterpolation();
+            tg.set_UseLineInterpolation(useLineInterpolation);
+            tg.set_LineType(lineType);
+            let status: string = tg.get_Status();
+            tg.set_VisibleModifiers(true);
+            //set tg latlongs and pixels
+            clsRenderer.setClientCoords(milStd, tg);
+            //build tg.Pixels
+            tg.Pixels = clsUtility.LatLongToPixels(tg.LatLongs, converter);
+            //tg.set_Font(new Font("Arial", Font.PLAIN, 12));
+            let r: RendererSettings = RendererSettings.getInstance();
+            let type: int = r.getMPLabelFontType();
+            let name: string = r.getMPLabelFontName();
+            let sz: int = r.getMPLabelFontSize();
+            let font: Font = new Font(name, type, sz);
+            tg.set_Font(font);
+            tg.set_FillColor(milStd.getFillColor());
+            tg.set_LineColor(milStd.getLineColor());
+            tg.set_LineThickness(milStd.getLineWidth());
+            tg.set_TexturePaint(milStd.getFillStyle());
+            tg.set_Fillstyle(milStd.getPatternFillType());
+            tg.set_patternScale(milStd.getPatternScale());
+
+            tg.setIconSize(milStd.getUnitSize());
+            tg.set_KeepUnitRatio(milStd.getKeepUnitRatio());
+
+            tg.set_FontBackColor(Color.WHITE);
+            tg.set_TextColor(milStd.getTextColor());
+            if (milStd.getModifier(Modifiers.W_DTG_1) != null) {
+                tg.set_DTG(milStd.getModifier(Modifiers.W_DTG_1));
+            }
+            if (milStd.getModifier(Modifiers.W1_DTG_2) != null) {
+                tg.set_DTG1(milStd.getModifier(Modifiers.W1_DTG_2));
+            }
+            if (milStd.getModifier(Modifiers.H_ADDITIONAL_INFO_1) != null) {
+                tg.set_H(milStd.getModifier(Modifiers.H_ADDITIONAL_INFO_1));
+            }
+            if (milStd.getModifier(Modifiers.H1_ADDITIONAL_INFO_2) != null) {
+                tg.set_H1(milStd.getModifier(Modifiers.H1_ADDITIONAL_INFO_2));
+            }
+            if (milStd.getModifier(Modifiers.H2_ADDITIONAL_INFO_3) != null) {
+                tg.set_H2(milStd.getModifier(Modifiers.H2_ADDITIONAL_INFO_3));
+            }
+            if (milStd.getModifier(Modifiers.T_UNIQUE_DESIGNATION_1) != null) {
+                tg.set_Name(milStd.getModifier(Modifiers.T_UNIQUE_DESIGNATION_1));
+            }
+            if (milStd.getModifier(Modifiers.T1_UNIQUE_DESIGNATION_2) != null) {
+                tg.set_T1(milStd.getModifier(Modifiers.T1_UNIQUE_DESIGNATION_2));
+            }
+            if (milStd.getModifier(Modifiers.V_EQUIP_TYPE) != null) {
+                tg.set_V(milStd.getModifier(Modifiers.V_EQUIP_TYPE));
+            }
+            if (milStd.getModifier(Modifiers.AS_COUNTRY) != null) {
+                tg.set_AS(milStd.getModifier(Modifiers.AS_COUNTRY));
+            }
+            if (milStd.getModifier(Modifiers.AP_TARGET_NUMBER) != null) {
+                tg.set_AP(milStd.getModifier(Modifiers.AP_TARGET_NUMBER));
+            }
+            if (milStd.getModifier(Modifiers.Y_LOCATION) != null) {
+                tg.set_Location(milStd.getModifier(Modifiers.Y_LOCATION));
+            }
+            if (milStd.getModifier(Modifiers.N_HOSTILE) != null) {
+                tg.set_N(milStd.getModifier(Modifiers.N_HOSTILE));
+            }
+            tg.set_UseDashArray(milStd.getUseDashArray());
+            tg.set_UseHatchFill(milStd.getUseFillPattern());
+            //tg.set_UsePatternFill(milStd.getUseFillPattern());
+            tg.set_HideOptionalLabels(milStd.getHideOptionalLabels());
+            let isClosedArea: boolean = clsUtilityJTR.isClosedPolygon(lineType);
+
+            if (isClosedArea) {
+                clsUtilityJTR.ClosePolygon(tg.Pixels);
+                clsUtilityJTR.ClosePolygon(tg.LatLongs);
+            }
+
+            let strXAlt: string = "";
+            //construct the H1 and H2 modifiers for sector from the mss AM, AN, and X arraylists
+            if (lineType == TacticalLines.BS_ELLIPSE) {
+                let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                let AN: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                //ensure array length 3
+                let r2: double =0;
+                let b: double =0;
+                if(AM.length==1)
+                {
+                    r2=AM[0];
+                    AM.push(r2);
+                    AM.push(0);
+                }
+                else if(AM.length==2)
+                {
+                    r2=AM[0];
+                    b=AM[1];
+                    AM[1] = r2;
+                    AM.push(b);
+                }
+                if (AN == null) {
+                    AN = [];
+                }
+                if (AN.length < 1) {
+                    AN.push(0);
+                }
+                if (AM != null && AM.length >= 2 && AN != null && AN.length >= 1) {
+                    let ptAzimuth: POINT2 = new POINT2(0, 0);
+                    ptAzimuth.x = AN[0];
+                    let ptCenter: POINT2 = tg.Pixels[0];
+                    let pt0: POINT2 = mdlGeodesic.geodesic_coordinate(tg.LatLongs[0], AM[0], 90);//semi-major axis
+                    let pt1: POINT2 = mdlGeodesic.geodesic_coordinate(tg.LatLongs[0], AM[1], 0);//semi-minor axis
+                    let pt02d: Point2D = new Point2D(pt0.x, pt0.y);
+                    let pt12d: Point2D = new Point2D(pt1.x, pt1.y);
+                    pt02d = converter.GeoToPixels(pt02d);
+                    pt12d = converter.GeoToPixels(pt12d);
+                    pt0 = new POINT2(pt02d.getX(), pt02d.getY());
+                    pt1 = new POINT2(pt12d.getX(), pt12d.getY());
+                    tg.Pixels = [];
+                    tg.Pixels.push(ptCenter);
+                    tg.Pixels.push(pt0);
+                    tg.Pixels.push(pt1);
+                    tg.Pixels.push(ptAzimuth);
+                }
+                if(AM != null && AM.length>2)
+                {
+                    //use AM[2] for the buffer, so PBS_CIRCLE requires AM size 3 like PBS_ELLIPSE to use a buffer
+                    let dist: double=AM[2];
+                    let pt0: POINT2=mdlGeodesic.geodesic_coordinate(tg.LatLongs[0], dist, 45);   //azimuth 45 is arbitrary
+                    let pt02d: Point2D = new Point2D(tg.LatLongs[0].x,tg.LatLongs[0].y);
+                    let pt12d: Point2D = new Point2D(pt0.x, pt0.y);
+                    pt02d = converter.GeoToPixels(pt02d);
+                    pt12d = converter.GeoToPixels(pt12d);
+                    pt0=new POINT2(pt02d.getX(),pt02d.getY());
+                    let pt1: POINT2=new POINT2(pt12d.getX(),pt12d.getY());
+                    dist=lineutility.CalcDistanceDouble(pt0, pt1);
+                    //arraysupport will use line style to create the buffer shape
+                    tg.Pixels[0].style=Math.trunc(dist);
+                }
+            }
+            let j: int = 0;
+            if (lineType == TacticalLines.BBS_RECTANGLE || lineType == TacticalLines.BS_BBOX) {
+                let minLat: double = tg.LatLongs[0].y;
+                let maxLat: double = tg.LatLongs[0].y;
+                let minLong: double = tg.LatLongs[0].x;
+                let maxLong: double = tg.LatLongs[0].x;
+                for (j = 1; j < tg.LatLongs.length; j++) {
+                    if (tg.LatLongs[j].x < minLong) {
+                        minLong = tg.LatLongs[j].x;
+                    }
+                    if (tg.LatLongs[j].x > maxLong) {
+                        maxLong = tg.LatLongs[j].x;
+                    }
+                    if (tg.LatLongs[j].y < minLat) {
+                        minLat = tg.LatLongs[j].y;
+                    }
+                    if (tg.LatLongs[j].y > maxLat) {
+                        maxLat = tg.LatLongs[j].y;
+                    }
+                }
+                tg.LatLongs = [];
+                tg.LatLongs.push(new POINT2(minLong, maxLat));
+                tg.LatLongs.push(new POINT2(maxLong, maxLat));
+                tg.LatLongs.push(new POINT2(maxLong, minLat));
+                tg.LatLongs.push(new POINT2(minLong, minLat));
+                if (lineType == TacticalLines.BS_BBOX) {
+                    tg.LatLongs.push(new POINT2(minLong, maxLat));
+                }
+                tg.Pixels = clsUtility.LatLongToPixels(tg.LatLongs, converter);
+            }
+            //these have a buffer value in meters which we'll stuff tg.H2
+            //and use the style member of tg.Pixels to stuff the buffer width in pixels
+            switch (lineType) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_RECTANGLE:
+                    let H2: string = null;
+                    let dist: double = 0;
+                    let pt0: POINT2;
+                    let pt1: POINT2;//45 is arbitrary
+                    let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                    if (AM != null && AM.length > 0) {
+                        H2 = AM[0].toString();
+                        tg.set_H2(H2);
+                    }
+                    if (H2 != null && !(H2.length === 0)) {
+                        for (j = 0; j < tg.LatLongs.length; j++) {
+                            if (tg.LatLongs.length > j) {
+                                if (!isNaN(parseFloat(H2))) {
+                                    if (j == 0) {
+                                        dist = parseFloat(H2);
+                                        pt0 = new POINT2(tg.LatLongs[0]);
+                                        pt1 = mdlGeodesic.geodesic_coordinate(pt0, dist, 45);//45 is arbitrary
+                                        let pt02d: Point2D = new Point2D(pt0.x, pt0.y);
+                                        let pt12d: Point2D = new Point2D(pt1.x, pt1.y);
+                                        pt02d = converter.GeoToPixels(pt02d);
+                                        pt12d = converter.GeoToPixels(pt12d);
+                                        pt0.x = pt02d.getX();
+                                        pt0.y = pt02d.getY();
+                                        pt1.x = pt12d.getX();
+                                        pt1.y = pt12d.getY();
+                                        dist = lineutility.CalcDistanceDouble(pt0, pt1);
+                                    }
+                                    tg.Pixels[j].style = Math.round(dist);
+                                } else {
+                                    tg.Pixels[j].style = 0;
+                                }
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+            if (lineType == TacticalLines.PBS_ELLIPSE) //geo ellipse
+            {
+                let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                let AN: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (AM != null && AM.length > 1) {
+                    let strAM: string = AM[0].toString(); // major axis
+                    tg.set_AM(strAM);
+                    let strAM1: string = AM[1].toString(); // minor axis
+                    tg.set_AM1(strAM1);
+                }
+                if (AN != null && AN.length > 0) {
+                    let strAN: string = AN[0].toString(); // rotation
+                    tg.set_AN(strAN);
+                }
+            }
+            switch (lineType) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_POINT:
+                case TacticalLines.BBS_RECTANGLE:
+                    if (tg.get_FillColor() == null) {
+                        tg.set_FillColor(Color.LIGHT_GRAY);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            switch (lineType) {
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.BBS_POINT:
+                    let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                    if (AM != null && AM.length > 0) {
+                        let strAM: string = String(AM[0]);
+                        //set width for rectangles or radius for circles
+                        tg.set_AM(strAM);
+                    } else if (lineType == TacticalLines.BBS_POINT && tg.LatLongs.length > 1) {
+                        let dist: double = mdlGeodesic.geodesic_distance(tg.LatLongs[0], tg.LatLongs[1], null, null);
+                        let strT1: string = String(dist);
+                        tg.set_T1(strT1);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            if (lineType == TacticalLines.PBS_RECTANGLE || lineType == TacticalLines.PBS_SQUARE) {
+                let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                let AN: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (lineType == TacticalLines.PBS_SQUARE) //for square
+                {
+                    let r2: double=AM[0];
+                    let b: double=0;
+                    if(AM.length==1)
+                    {
+                        AM.push(r2);
+                        AM.push(b);
+                    }
+                    else if(AM.length==2)
+                    {
+                        b=AM[1];
+                        AM[1] = r2;
+                        AM.push(b);
+                    }
+                    else if(AM.length>2)
+                        AM[1] = r2;
+                }
+                //if all these conditions are not met we do not want to set any tg modifiers
+                if (lineType == TacticalLines.PBS_SQUARE) //square
+                {
+                    let am0: double = AM[0];
+                    if (AM.length == 1) {
+                        AM.push(am0);
+                    } else if (AM.length >= 2) {
+                        AM[1] = am0;
+                    }
+                }
+                if (AN == null) {
+                    AN = [];
+                }
+                if (AN.length === 0) {
+                    AN.push(0);
+                }
+
+                if (AM != null && AM.length > 1) {
+                    let strAM: string = String(AM[0]);    //width
+                    let strAM1: string = String(AM[1]);     //length
+                    //set width and length in meters for rectangular target
+                    tg.set_AM(strAM);
+                    tg.set_AM1(strAM1);
+                    //set attitude in degrees
+                    let strAN: string = String(AN[0]);
+                    tg.set_AN(strAN);
+                }
+                /*
+                if(AM.length>2)
+                {
+                    let strH1: string = string(AM.get(2));     //buffer size
+                    tg.set_H1(strH1);
+                }
+                 */
+            }
+        } catch (exc) {
+            if (exc instanceof Error) {
+               ErrorLogger.LogException("clsRenderer", "createTGLightFromBasicMilStdSymbol",
+                    new RendererException("Failed to build multipoint TG for " + lineType, exc));
+            } else {
+                throw exc;
+            }
+        }
+
+        return tg;
     }
 
     /**
@@ -647,7 +983,7 @@ export class clsRenderer {
                         /*
                         if(AM.length>2)
                         {
-                            String strH1 = Double.toString(AM[2]);     //buffer size
+                            let strH1: string = string(AM[2]);     //buffer size
                             tg.set_H1(strH1);
                         }
                          */
@@ -897,8 +1233,8 @@ export class clsRenderer {
                     } else {
                         if (clipArea instanceof Array) {
                             clipPoints = clipArea as Array<Point2D>;
-                            //double x0=clipPoints[0].getX(),y0=clipPoints[0].getY();
-                            //double w=clipPoints[1].getX()-x0,h=clipPoints[3].getY()-y0;
+                            //let x0: double=clipPoints[0].getX(),y0=clipPoints[0].getY();
+                            //let w: double=clipPoints[1].getX()-x0,h=clipPoints[3].getY()-y0;
                             //clipBounds = new Rectangle2D(x0, y0, w, h);
                             clipBounds = clsUtility.getMBR(clipPoints);
                         }
@@ -1003,7 +1339,7 @@ export class clsRenderer {
 
             //            if (coordsRight - coordsLeft > 180)
             //            {
-            //                double temp = coordsLeft;
+            //                let temp: double = coordsLeft;
             //                coordsLeft = coordsRight;
             //                coordsRight = temp;
             //                coordSpanIDL=true;
@@ -1269,7 +1605,7 @@ export class clsRenderer {
 
                     //            boolean shiftLines = Channels.getShiftLines();
                     //            if (shiftLines) {
-                    //                String affiliation = tg.get_Affiliation();
+                    //                let affiliation: string = tg.get_Affiliation();
                     //                Channels.setAffiliation(affiliation);
                     //            }
                     //CELineArray.setMinLength(2.5);    //2-27-2013
@@ -1632,6 +1968,38 @@ export class clsRenderer {
         }
     }
 
+    private static resolvePostClippedShapes(tg: TGLight, shapes: Array<Shape2>): void {
+        try {
+            //resolve the PBS and BBS shape properties after the post clip, regardless whether they were clipped
+            switch (tg.get_LineType()) {
+                case TacticalLines.BBS_RECTANGLE:
+                case TacticalLines.BBS_POINT:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
+                    break;
+                default:
+                    return;
+            }
+            let fillColor: Color = tg.get_FillColor();
+            shapes[0].setFillColor(fillColor);
+            shapes[1].setFillColor(null);
+            let fillStyle: int = tg.get_FillStyle();
+            shapes[0].setFillStyle(0);
+            shapes[1].setFillStyle(fillStyle);
+            return;
+
+        } catch (exc) {
+            if (exc instanceof Error) {
+                ErrorLogger.LogException(clsRenderer._className, "resolvePostClippedShapes",
+                    new RendererException("Failed inside resolvePostClippedShapes", exc));
+            } else {
+                throw exc;
+            }
+        }
+    }
+
     /**
      * set the clip rectangle as an arraylist or a Rectangle2D depending on the
      * object
@@ -1737,7 +2105,7 @@ export class clsRenderer {
                     clsRenderer.reversePointsRevD(tg);
                     CELineArray.setClient("generic");
                     //            if (shiftLines) {
-                    //                String affiliation = tg.get_Affiliation();
+                    //                let affiliation: string = tg.get_Affiliation();
                     //                Channels.setAffiliation(affiliation);
                     //            }
                     //CELineArray.setMinLength(2.5);    //2-27-2013

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -1459,6 +1459,7 @@ export class clsRenderer {
                             shapes = clsUtilityCPOF.postClipShapes(tg, shapes, clipPoints);
                         }
                     }
+                    clsRenderer.resolvePostClippedShapes(tg,shapes);
 
                     //returns early if textSpecs are null
                     //currently the client is ignoring these

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer2.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer2.ts
@@ -292,7 +292,8 @@ export class clsRenderer2 {
                 else {
                     //this will help with click-drag mode
                     if (tg.Pixels.length < 2) {
-                        return null;
+                        if(lineType != TacticalLines.BS_CROSS)
+                            return null;
                     }
 
 

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtility.ts
@@ -60,7 +60,15 @@ export class clsUtility {
             //                    return;
             if (clsUtilityJTR.isClosedPolygon(lineType) === false) {
                 if (clsUtilityJTR.IsChange1Area(lineType) === false) {
-                    return;
+                    switch(lineType)
+                    {
+                        case TacticalLines.BBS_AREA:
+                        case TacticalLines.BBS_LINE:
+                        case TacticalLines.BBS_RECTANGLE:
+                            break;
+                        default:
+                            return;
+                    }
                 }
             }
 

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -93,7 +93,9 @@ export class clsUtilityCPOF {
             length.value = new Array<number>(1);
             switch (lineType) {
                 case TacticalLines.CIRCULAR:
+                case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.FFA_CIRCULAR:
@@ -120,7 +122,8 @@ export class clsUtilityCPOF {
 
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
-                case TacticalLines.SHIP_AOI_CIRCULAR: {
+                case TacticalLines.SHIP_AOI_CIRCULAR:
+                case TacticalLines.PBS_ELLIPSE: {
                     //minor radius in meters
                     if (SymbolUtilities.isNumber(tg.get_AM1())) {
                         length.value[0] = parseFloat(tg.get_AM1());
@@ -148,6 +151,22 @@ export class clsUtilityCPOF {
                     //so we must multiply by 360/6400 to convert to degrees
                     if (SymbolUtilities.isNumber(tg.get_AN())) {
                         attitude.value[0] = parseFloat(tg.get_AN()) * (360 / 6400);
+                    }
+                    break;
+                }
+
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE: {
+                    if (SymbolUtilities.isNumber(tg.get_AM1())) {
+                        length.value[0] = parseFloat(tg.get_AM1());
+                    }
+                    if (SymbolUtilities.isNumber(tg.get_AM())) {
+                        width.value[0] = parseFloat(tg.get_AM());
+                    }
+                    //assume that attitude was passed in mils
+                    //so we must multiply by 360/6400 to convert to degrees                    
+                    if (SymbolUtilities.isNumber(tg.get_AN())) {
+                        attitude.value[0] = parseFloat(tg.get_AN());
                     }
                     break;
                 }
@@ -332,7 +351,8 @@ export class clsUtilityCPOF {
             switch (lineType) {
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
-                case TacticalLines.SHIP_AOI_CIRCULAR: {
+                case TacticalLines.SHIP_AOI_CIRCULAR:
+                case TacticalLines.PBS_ELLIPSE: {
                     let ellipsePts: POINT2[] = mdlGeodesic.getGeoEllipse(pt0, width.value[0], length.value[0], attitude.value[0]);
                     for (j = 0; j < ellipsePts.length; j++) //was 103
                     {
@@ -452,6 +472,8 @@ export class clsUtilityCPOF {
                 }
 
                 case TacticalLines.RECTANGULAR:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
                 case TacticalLines.CUED_ACQUISITION: {
                     //AFATDS swap length and width
                     //comment next three lines to render per Mil-Std-2525
@@ -492,7 +514,9 @@ export class clsUtilityCPOF {
                 }
 
                 case TacticalLines.CIRCULAR:
+                case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.ACA_CIRCULAR:
@@ -597,6 +621,42 @@ export class clsUtilityCPOF {
                 //load left and right shapes into shapes
                 shapes.push(...shapesLeft);
                 shapes.push(...shapesRight);
+            }
+            if (lineType == TacticalLines.BBS_POINT) {
+                let shape: Shape2 = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                shape.moveTo(ptCenter);
+                //ptCenter.x+=1;
+                ptCenter.y += 1;
+                shape.lineTo(ptCenter);
+                shapes.push(shape);
+            }
+            if (lineType == TacticalLines.PBS_RECTANGLE || lineType == TacticalLines.PBS_SQUARE)
+            {
+                let dist: double = radius.value[0];//Double.parseDouble(strH1);
+                pt0 = new POINT2(tg.LatLongs[0]);
+                pt1 = mdlGeodesic.geodesic_coordinate(pt0, dist, 45);//45 is arbitrary
+                let pt02d: Point2D = new Point2D(pt0.x, pt0.y);
+                let pt12d: Point2D = new Point2D(pt1.x, pt1.y);
+                pt02d = converter.GeoToPixels(pt02d);
+                pt12d = converter.GeoToPixels(pt12d);
+                pt0.x = pt02d.getX();
+                pt0.y = pt02d.getY();
+                pt1.x = pt12d.getX();
+                pt1.y = pt12d.getY();
+                dist = lineutility.CalcDistanceDouble(pt0, pt1);    //pixels distance
+                //tg.Pixels.get(0).style=(int)dist;
+                let tempPixels: Array<POINT2> = [];
+                tempPixels.push(...tg.Pixels);
+                let pts: POINT2[] = tempPixels;
+                pts[0].style=Math.trunc(dist);
+                lineutility.getExteriorPoints(pts, pts.length, lineType, false);
+                tg.Pixels.length = 0;
+                for(j=0;j<pts.length;j++)
+                    tg.Pixels.push(new POINT2(pts[j].x,pts[j].y));
+
+                clsUtilityCPOF.Change1PixelsToShapes(tg, shapes, true);
+                //reuse the original pixels for the subsequent call to AddModifier2
+                tg.Pixels = tempPixels;
             }
             return true;
         } catch (exc) {
@@ -1127,13 +1187,17 @@ export class clsUtilityCPOF {
             //do not clear pixel style for the air corridors because
             //arraysupport is using linestyle for these to set the segment width         
             switch (tg.get_LineType()) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_RECTANGLE:
                 case TacticalLines.SC:
                 case TacticalLines.MRR:
                 case TacticalLines.SL:
                 case TacticalLines.TC:
                 case TacticalLines.LLTR:
                 case TacticalLines.AC:
-                case TacticalLines.SAAFR: {
+                case TacticalLines.SAAFR:
+                case TacticalLines.BS_ELLIPSE: {
                     return;
                 }
 
@@ -1364,6 +1428,8 @@ export class clsUtilityCPOF {
                 case TacticalLines.JTAA:
                 case TacticalLines.SAA:
                 case TacticalLines.SGAA:
+                case TacticalLines.BS_AREA:
+                case TacticalLines.BS_LINE:
                 case TacticalLines.ASSY:
                 case TacticalLines.EA:
                 case TacticalLines.FORT_REVD:
@@ -2062,6 +2128,9 @@ export class clsUtilityCPOF {
             }
             //do not pre-segment the autoshapes
             if (clsUtilityJTR.isAutoshape(tg)) {
+                return false;
+            }
+            if (SymbolUtilities.isBasicShape(linetype)) {
                 return false;
             }
             //temporarily do not pre-segment the channel types.

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityGE.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityGE.ts
@@ -389,6 +389,9 @@ export class clsUtilityGE {
 
 
             switch (linetype) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_RECTANGLE:
+
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.AIRAOA:

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
@@ -2,6 +2,7 @@ import { type int, type double } from "../../graphics2d/BasicTypes";
 
 import { Point } from "../../graphics2d/Point";
 import { Rectangle2D } from "../../graphics2d/Rectangle2D"
+import { TacticalLines } from "../../JavaLineArray/TacticalLines";
 import { AffiliationColors } from "../../renderer/utilities/AffiliationColors"
 import { Color } from "../../renderer/utilities/Color"
 import { DrawRules } from "../../renderer/utilities/DrawRules"
@@ -2050,6 +2051,34 @@ export class SymbolUtilities {
         }
 
         return rw;
+    }
+
+     /**
+     * @param linetype the line type
+     * @return true if the line is a basic shape
+     */
+    public static isBasicShape(linetype: int): boolean {
+        switch (linetype) {
+            case TacticalLines.BS_AREA:
+            case TacticalLines.BS_LINE:
+            case TacticalLines.BS_CROSS:
+            case TacticalLines.BS_ELLIPSE:
+            case TacticalLines.PBS_ELLIPSE:
+            case TacticalLines.PBS_CIRCLE:
+            case TacticalLines.PBS_SQUARE:
+            case TacticalLines.PBS_RECTANGLE:
+            case TacticalLines.BS_RECTANGLE:
+            case TacticalLines.BBS_AREA:
+            case TacticalLines.BBS_LINE:
+            case TacticalLines.BBS_POINT:
+            case TacticalLines.BBS_RECTANGLE:
+            case TacticalLines.BS_BBOX: {
+                return true;
+            }
+            default: {
+                return false;
+            }
+        }
     }
 
 }

--- a/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
@@ -3188,4 +3188,611 @@ export class MultiPointHandler {
             }
         }
     }
+
+    /**
+     *
+     * @param id
+     * @param name
+     * @param description
+     * @param basicShapeType
+     * @param controlPoints
+     * @param scale
+     * @param bbox
+     * @param symbolModifiers
+     * @param symbolAttributes
+     * @return
+     */
+    public static RenderBasicShapeAsMilStdSymbol(id: string,
+        name: string,
+        description: string,
+        basicShapeType: int,
+        controlPoints: string,
+        scale: number,
+        bbox: string,
+        symbolModifiers: Map<string, string>,
+        symbolAttributes: Map<string, string>): MilStdSymbol
+    {
+        let mSymbol: MilStdSymbol;
+        let normalize: boolean = true;
+        let controlLat: number = 0.0;
+        let controlLong: number = 0.0;
+        //String jsonContent = "";
+
+        let rect: Rectangle;
+
+        //for symbol & line fill
+        let tgPoints: Array<POINT2>;
+
+        let coordinates: string[] = controlPoints.split(" ");
+        let shapes: Array<ShapeInfo>;//new ArrayList<ShapeInfo>();
+        let modifiers: Array<ShapeInfo>;//new ArrayList<ShapeInfo>();
+        //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
+        let geoCoords: Array<Point2D> = new Array<Point2D>();
+        let len: int = coordinates.length;
+
+        let ipc: IPointConversion;
+
+        //Deutch moved section 6-29-11
+        let left: number = 0.0;
+        let right: number = 0.0;
+        let top: number = 0.0;
+        let bottom: number = 0.0;
+        let temp: Point2D;
+        let ptGeoUL: Point2D;
+        let width: int = 0;
+        let height: int = 0;
+        let leftX: int = 0;
+        let topY: int = 0;
+        let bottomY: int = 0;
+        let rightX: int = 0;
+        let j: int = 0;
+        let bboxCoords: Array<Point2D>;
+        if (bbox != null && bbox !== "") {
+            let bounds: string[];
+            if (bbox.includes(" "))//trapezoid
+            {
+                bboxCoords = new Array<Point2D>();
+                let x: double = 0;
+                let y: double = 0;
+                let coords: string[] = bbox.split(" ");
+                let arrCoord: string[];
+                for (let coord of coords) {
+                    arrCoord = coord.split(",");
+                    x = parseFloat(arrCoord[0]);
+                    y = parseFloat(arrCoord[1]);
+                    bboxCoords.push(new Point2D(x, y));
+                }
+                //use the upper left corner of the MBR containing geoCoords
+                //to set the converter
+                ptGeoUL = MultiPointHandler.getGeoUL(bboxCoords);
+                left = ptGeoUL.getX();
+                top = ptGeoUL.getY();
+                ipc = new PointConverter(left, top, scale);
+                let ptPixels: Point2D;
+                let ptGeo: Point2D;
+                let n: int = bboxCoords.length;
+                //for (j = 0; j < bboxCoords.length; j++) 
+                for (j = 0; j < n; j++) {
+                    ptGeo = bboxCoords[j];
+                    ptPixels = ipc.GeoToPixels(ptGeo);
+                    x = ptPixels.getX();
+                    y = ptPixels.getY();
+                    if (x < 20) {
+                        x = 20;
+                    }
+                    if (y < 20) {
+                        y = 20;
+                    }
+                    ptPixels.setLocation(x, y);
+                    //end section
+                    bboxCoords[j] = ptPixels;
+                }
+            } else//rectangle
+            {
+                bounds = bbox.split(",");
+                left = parseFloat(bounds[0]);
+                right = parseFloat(bounds[2]);
+                top = parseFloat(bounds[3]);
+                bottom = parseFloat(bounds[1]);
+                scale = MultiPointHandler.getReasonableScale(bbox, scale);
+                ipc = new PointConverter(left, top, scale);
+            }
+
+            let pt2d: Point2D;
+            if (bboxCoords == null) {
+                pt2d = new Point2D(left, top);
+                temp = ipc.GeoToPixels(pt2d);
+
+                leftX = temp.getX() as int;
+                topY = temp.getY() as int;
+
+                pt2d = new Point2D(right, bottom);
+                temp = ipc.GeoToPixels(pt2d);
+
+                bottomY = temp.getY() as int;
+                rightX = temp.getX() as int;
+                //diagnostic clipping does not work for large scales
+                //                if (scale > 10e6) {
+                //                    //get widest point in the AOI
+                //                    double midLat = 0;
+                //                    if (bottom < 0 && top > 0) {
+                //                        midLat = 0;
+                //                    } else if (bottom < 0 && top < 0) {
+                //                        midLat = top;
+                //                    } else if (bottom > 0 && top > 0) {
+                //                        midLat = bottom;
+                //                    }
+                //
+                //                    temp = ipc.GeoToPixels(new Point2D(right, midLat));
+                //                    rightX = (int) temp.getX();
+                //                }
+                //end section
+
+                width = Math.abs(rightX - leftX) as int;
+                height = Math.abs(bottomY - topY) as int;
+
+                if (width === 0 || height === 0) {
+
+                    rect = null;
+                }
+
+                else {
+
+                    rect = new Rectangle(leftX, topY, width, height);
+                }
+
+            }
+        } else {
+            rect = null;
+        }
+        //end section
+
+        for (let i: int = 0; i < len; i++) {
+            let coordPair: string[] = coordinates[i].split(",");
+            let latitude: number = parseFloat(coordPair[1].trim());
+            let longitude: number = parseFloat(coordPair[0].trim());
+            geoCoords.push(new Point2D(longitude, latitude));
+        }
+        if (ipc == null) {
+            let ptCoordsUL: Point2D = MultiPointHandler.getGeoUL(geoCoords);
+            ipc = new PointConverter(ptCoordsUL.getX(), ptCoordsUL.getY(), scale);
+        }
+        //if (crossesIDL(geoCoords) == true) 
+        //        if(Math.abs(right-left)>180)
+        //        {
+        //            normalize = true;
+        //            ((PointConverter)ipc).set_normalize(true);
+        //        } 
+        //        else {
+        //            normalize = false;
+        //            ((PointConverter)ipc).set_normalize(false);
+        //        }
+
+        //seems to work ok at world view
+        //        if (normalize) {
+        //            NormalizeGECoordsToGEExtents(0, 360, geoCoords);
+        //        }
+
+        //M. Deutch 10-3-11
+        //must shift the rect pixels to synch with the new ipc
+        //the old ipc was in synch with the bbox, so rect x,y was always 0,0
+        //the new ipc synchs with the upper left of the geocoords so the boox is shifted
+        //and therefore the clipping rectangle must shift by the delta x,y between
+        //the upper left corner of the original bbox and the upper left corner of the geocoords
+        let geoCoords2: Array<Point2D> = new Array<Point2D>();
+        geoCoords2.push(new Point2D(left, top));
+        geoCoords2.push(new Point2D(right, bottom));
+
+        //        if (normalize) {
+        //            NormalizeGECoordsToGEExtents(0, 360, geoCoords2);
+        //        }
+
+        //disable clipping
+        if (MultiPointHandler.crossesIDL(geoCoords) === false) {
+            rect = null;
+            bboxCoords = null;
+        }
+
+        let symbolCode = "";
+        try {
+            let fillColor: string;
+            mSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
+
+            //            mSymbol.setUseDashArray(true);
+
+            if (symbolModifiers != null || symbolAttributes != null) {
+                MultiPointHandler.populateModifiers(symbolModifiers, symbolAttributes, mSymbol);
+            } else {
+                mSymbol.setFillColor(null);
+            }
+
+            if (mSymbol.getFillColor() != null) {
+                let fc: Color = mSymbol.getFillColor();
+                fillColor = RendererUtilities.colorToHexString(fc, false);
+
+            }
+       
+            let tg: TGLight = clsRenderer.createTGLightFromMilStdSymbolBasicShape(mSymbol, ipc, basicShapeType);
+            let shapeInfos: Array<ShapeInfo> = [];
+            let modifierShapeInfos: Array<ShapeInfo> = [];
+            let clipArea: Point2D[] | Rectangle | Rectangle2D;
+            if (bboxCoords == null) {
+                clipArea = rect;
+            } else {
+                clipArea = bboxCoords;
+            }
+            if (clsRenderer.intersectsClipArea(tg, ipc, clipArea)) {
+                clsRenderer.render_GE(tg, shapeInfos, modifierShapeInfos, ipc, clipArea);
+            }
+            mSymbol.setSymbolShapes(shapeInfos);
+            mSymbol.setModifierShapes(modifierShapeInfos);
+            mSymbol.set_WasClipped(tg.get_WasClipped());
+            shapes = mSymbol.getSymbolShapes();
+            modifiers = mSymbol.getModifierShapes();
+
+            //convert points////////////////////////////////////////////////////
+            let polylines: Array<Array<Point2D>>;
+            let newPolylines: Array<Array<Point2D>>;
+            let newLine: Array<Point2D>;
+            for (let shape of shapes) {
+                polylines = shape.getPolylines();
+                //console.log("pixel polylines: " + polylines.toString());
+                newPolylines = MultiPointHandler.ConvertPolylinePixelsToCoords(polylines, ipc, normalize);
+                shape.setPolylines(newPolylines);
+            }
+
+            for (let label of modifiers) {
+                let pixelCoord: Point2D = label.getModifierPosition();
+                if (pixelCoord == null) {
+                    pixelCoord = label.getGlyphPosition();
+                }
+                let geoCoord: Point2D = ipc.PixelsToGeo(pixelCoord);
+
+                if (normalize) {
+                    geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
+                }
+
+                let latitude: double = geoCoord.getY();
+                let longitude: double = geoCoord.getX();
+                label.setModifierPosition(new Point2D(longitude, latitude));
+
+            }
+
+            ////////////////////////////////////////////////////////////////////
+            mSymbol.setModifierShapes(modifiers);
+            mSymbol.setSymbolShapes(shapes);
+
+        } catch (exc) {
+            if (exc instanceof Error) {
+                console.log(exc.message);
+                console.log("Symbol Code: " + symbolCode);
+                console.log(exc.stack);
+            } else {
+                throw exc;
+            }
+        }
+
+        /*
+        let debug: boolean = false;
+        if (debug === true) {
+            console.log("Symbol Code: " + symbolCode);
+            console.log("Scale: " + scale);
+            console.log("BBOX: " + bbox);
+            if (controlPoints != null) {
+                console.log("Geo Points: " + controlPoints);
+            }
+            if (tgl != null && tgl.get_Pixels() != null)//pixels != null
+            {
+                //console.log("Pixel: " + pixels.toString());
+                console.log("Pixel: " + tgl.get_Pixels().toString());
+            }
+            if (bbox != null) {
+                console.log("geo bounds: " + bbox);
+            }
+            if (rect != null) {
+                console.log("pixel bounds: " + rect.toString());
+            }
+        }
+            */
+
+        return mSymbol;
+
+    }
+
+    /**
+     *
+     * @param id
+     * @param name
+     * @param description
+     * @param basicShapeType
+     * @param controlPoints
+     * @param scale
+     * @param bbox
+     * @param symbolModifiers {@link Map}, keyed using constants from
+     * Modifiers. Pass in comma delimited String for modifiers with multiple
+     * values like AM, AN &amp; X
+     * @param symbolAttributes {@link Map}, keyed using constants from
+     * MilStdAttributes. pass in double[] for AM, AN and X; Strings for the
+     * rest.
+     * @param format
+     * @return
+     */
+    public static RenderBasicShape(id: string,
+        name: string,
+        description: string,
+        basicShapeType: int,
+        controlPoints: string,
+        scale: number,
+        bbox: string,
+        symbolModifiers: Map<string, string>,
+        symbolAttributes: Map<string, string>,
+        format: int): string
+    {
+        let normalize: boolean = true;
+        //Double controlLat = 0.0;
+        //Double controlLong = 0.0;
+        //Double metPerPix = GeoPixelConversion.metersPerPixel(scale);
+        //String bbox2=getBoundingRectangle(controlPoints,bbox);
+        let jsonOutput: string = "";
+        let jsonContent: string = "";
+
+        let rect: Rectangle;
+        let coordinates: string[] = controlPoints.split(" ");
+        let shapes: Array<ShapeInfo> = new Array<ShapeInfo>();
+        let modifiers: Array<ShapeInfo> = new Array<ShapeInfo>();
+        //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
+        let geoCoords: Array<Point2D> = new Array<Point2D>();
+        let len: int = coordinates.length;
+        //diagnostic create geoCoords here
+        let coordsUL: Point2D = null;
+        const symbolCode = "";
+
+        for (let i: int = 0; i < len; i++) {
+            let coordPair: string[] = coordinates[i].split(",");
+            let latitude: number = parseFloat(coordPair[1].trim());
+            let longitude: number = parseFloat(coordPair[0].trim());
+            geoCoords.push(new Point2D(longitude, latitude));
+        }
+        let tgPoints: Array<POINT2>;
+        let ipc: IPointConversion;
+
+        //Deutch moved section 6-29-11
+        let left: number = 0.0;
+        let right: number = 0.0;
+        let top: number = 0.0;
+        let bottom: number = 0.0;
+        let temp: Point2D;
+        let ptGeoUL: Point2D;
+        let width: int = 0;
+        let height: int = 0;
+        let leftX: int = 0;
+        let topY: int = 0;
+        let bottomY: int = 0;
+        let rightX: int = 0;
+        let j: int = 0;
+        let bboxCoords: Array<Point2D>;
+        if (bbox != null && bbox !== "") {
+            let bounds: string[];
+            if (bbox.includes(" "))//trapezoid
+            {
+                bboxCoords = new Array<Point2D>();
+                let x: double = 0;
+                let y: double = 0;
+                let coords: string[] = bbox.split(" ");
+                let arrCoord: string[];
+                for (let coord of coords) {
+                    arrCoord = coord.split(",");
+                    x = parseFloat(arrCoord[0]);
+                    y = parseFloat(arrCoord[1]);
+                    bboxCoords.push(new Point2D(x, y));
+                }
+                //use the upper left corner of the MBR containing geoCoords
+                //to set the converter
+                ptGeoUL = MultiPointHandler.getGeoUL(bboxCoords);
+                left = ptGeoUL.getX();
+                top = ptGeoUL.getY();
+                let bbox2: string = MultiPointHandler.getBboxFromCoords(bboxCoords);
+                scale = MultiPointHandler.getReasonableScale(bbox2, scale);
+                ipc = new PointConverter(left, top, scale);
+                let ptPixels: Point2D;
+                let ptGeo: Point2D;
+                let n: int = bboxCoords.length;
+                //for (j = 0; j < bboxCoords.length; j++) 
+                for (j = 0; j < n; j++) {
+                    ptGeo = bboxCoords[j];
+                    ptPixels = ipc.GeoToPixels(ptGeo);
+                    x = ptPixels.getX();
+                    y = ptPixels.getY();
+                    if (x < 20) {
+                        x = 20;
+                    }
+                    if (y < 20) {
+                        y = 20;
+                    }
+                    ptPixels.setLocation(x, y);
+                    //end section
+                    bboxCoords[j] = ptPixels;
+                }
+            } else//rectangle
+            {
+                bounds = bbox.split(",");
+                left = parseFloat(bounds[0]);
+                right = parseFloat(bounds[2]);
+                top = parseFloat(bounds[3]);
+                bottom = parseFloat(bounds[1]);
+                scale = MultiPointHandler.getReasonableScale(bbox, scale);
+                ipc = new PointConverter(left, top, scale);
+            }
+
+            let pt2d: Point2D;
+            if (bboxCoords == null) {
+                pt2d = new Point2D(left, top);
+                temp = ipc.GeoToPixels(pt2d);
+
+                leftX = temp.getX() as int;
+                topY = temp.getY() as int;
+
+                pt2d = new Point2D(right, bottom);
+                temp = ipc.GeoToPixels(pt2d);
+
+                bottomY = temp.getY() as int;
+                rightX = temp.getX() as int;
+
+                width = Math.abs(rightX - leftX) as int;
+                height = Math.abs(bottomY - topY) as int;
+
+                rect = new Rectangle(leftX, topY, width, height);
+            }
+        } else {
+            rect = null;
+        }
+
+        if (ipc == null) {
+            let ptCoordsUL: Point2D = MultiPointHandler.getGeoUL(geoCoords);
+            ipc = new PointConverter(ptCoordsUL.getX(), ptCoordsUL.getY(), scale);
+        }
+       
+        let geoCoords2: Array<Point2D> = new Array<Point2D>();
+        geoCoords2.push(new Point2D(left, top));
+        geoCoords2.push(new Point2D(right, bottom));
+
+        //        if (normalize) {
+        //            NormalizeGECoordsToGEExtents(0, 360, geoCoords2);
+        //        }
+
+        try {
+
+            //String fillColor = null;
+            let mSymbol: MilStdSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
+            
+            if (format == WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                // Use dash array and hatch pattern fill for SVG output
+                symbolAttributes.set(MilStdAttributes.UseDashArray, 'true')
+                symbolAttributes.set(MilStdAttributes.UsePatternFill, "true")
+            }
+
+            if (symbolModifiers != null || symbolAttributes != null) {
+                MultiPointHandler.populateModifiers(symbolModifiers, symbolAttributes, mSymbol);
+            } else {
+                mSymbol.setFillColor(null);
+            }
+
+            let tg: TGLight = clsRenderer.createTGLightFromMilStdSymbolBasicShape(mSymbol, ipc, basicShapeType);
+            let shapeInfos: Array<ShapeInfo> = [];
+            let modifierShapeInfos: Array<ShapeInfo> = [];
+            let clipArea: Point2D[] | Rectangle | Rectangle2D;
+            if (bboxCoords == null) {
+                clipArea = rect;
+            } else {
+                clipArea = bboxCoords;
+            }
+            if (clsRenderer.intersectsClipArea(tg, ipc, clipArea)) {
+                clsRenderer.render_GE(tg, shapeInfos, modifierShapeInfos, ipc, clipArea);
+            }
+            mSymbol.setSymbolShapes(shapeInfos);
+            mSymbol.setModifierShapes(modifierShapeInfos);
+            mSymbol.set_WasClipped(tg.get_WasClipped());
+            shapes = mSymbol.getSymbolShapes();
+            modifiers = mSymbol.getModifierShapes();
+
+            if (format === WebRenderer.OUTPUT_FORMAT_JSON) {
+                jsonOutput += ("{\"type\":\"symbol\",");
+                jsonContent = MultiPointHandler.JSONize(shapes, modifiers, ipc, true, normalize);
+                jsonOutput += (jsonContent);
+                jsonOutput += ("}");
+            } else if (format === WebRenderer.OUTPUT_FORMAT_KML) {
+                var textColor = mSymbol.getTextColor();
+                if(textColor==null)
+                    textColor=mSymbol.getLineColor();
+
+                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonOutput += jsonContent;
+            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
+                /*
+                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput += (jsonContent);
+                jsonOutput += (",\"properties\":{\"id\":\"");
+                jsonOutput += (id);
+                jsonOutput += ("\",\"name\":\"");
+                jsonOutput += (name);
+                jsonOutput += ("\",\"description\":\"");
+                jsonOutput += (description);
+                jsonOutput += ("\",\"symbolID\":\"");
+                jsonOutput += (symbolCode);
+                jsonOutput += ("\",\"wasClipped\":\"");
+                jsonOutput += (mSymbol.get_WasClipped()).toString();
+                jsonOutput += ("\"}}");         */
+
+                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = MultiPointHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput += (jsonContent);
+
+                //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
+                jsonOutput = jsonOutput.slice(0, -1);
+                jsonOutput += (",{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+
+                jsonOutput += (",\"properties\":{\"id\":\"");
+                jsonOutput += (id);
+                jsonOutput += ("\",\"name\":\"");
+                jsonOutput += (name);
+                jsonOutput += ("\",\"description\":\"");
+                jsonOutput += (description);
+                jsonOutput += ("\",\"symbolID\":\"");
+                jsonOutput += (symbolCode);
+                jsonOutput += ("\",\"wasClipped\":\"");
+                jsonOutput += (mSymbol.get_WasClipped()).toString();
+                //jsonOutput += ("\"}}");
+
+                jsonOutput += ("\"}}]}");
+            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                let textColor = mSymbol.getTextColor() ? mSymbol.getTextColor().toHexString(false) : "";
+                let backgroundColor = mSymbol.getTextBackgroundColor() ? mSymbol.getTextBackgroundColor().toHexString(false) : "";
+                //returns an svg with a geoTL and geoBR value to use to place the canvas on the map
+                jsonOutput = MultiPointHandlerSVG.GeoSVGize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, backgroundColor, mSymbol.get_WasClipped());
+            }
+        } catch (exc) {
+            if (exc instanceof Error) {
+                let st: string = JavaRendererUtilities.getStackTrace(exc);
+                jsonOutput = "";
+                jsonOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + ": " + "- ");
+                jsonOutput += (exc.message + " - ");
+                jsonOutput += (st);
+                jsonOutput += ("\"}");
+
+                ErrorLogger.LogException("MultiPointHandler", "RenderBasicSymbol", exc);
+            } else {
+                throw exc;
+            }
+        }
+
+        /*
+        let debug: boolean = false;
+        if (debug === true) {
+            console.log("Symbol Code: " + symbolCode);
+            console.log("Scale: " + scale);
+            console.log("BBOX: " + bbox);
+            if (controlPoints != null) {
+                console.log("Geo Points: " + controlPoints);
+            }
+            if (tgl != null && tgl.get_Pixels() != null)//pixels != null
+            {
+                console.log("Pixel: " + tgl.get_Pixels().toString());
+            }
+            if (bbox != null) {
+                console.log("geo bounds: " + bbox);
+            }
+            if (rect != null) {
+                console.log("pixel bounds: " + rect.toString());
+            }
+            if (jsonOutput != null) {
+                console.log(jsonOutput.toString());
+            }
+        }
+            */
+
+        ErrorLogger.LogMessage("MultiPointHandler", "RenderBasicShape()", "exit RenderBasicShape", LogLevel.FINER);
+        return jsonOutput.toString();
+
+    }
 }

--- a/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
@@ -24,7 +24,7 @@ import { RendererUtilities } from "../../renderer/utilities/RendererUtilities";
 import { mdlGeodesic } from "../../JavaTacticalRenderer/mdlGeodesic"
 import { POINT2 } from "../../JavaLineArray/POINT2";
 import { ref } from "../../JavaLineArray/ref"
-
+import { BasicShapes } from "../../JavaLineArray/BasicShapes";
 
 
 /**
@@ -427,7 +427,136 @@ export class WebRenderer /* extends Applet */ {
         return mSymbol;
     }
 
+    /**
+     * Renders all MilStd 2525 multi-point symbols, creating MilStdSymbol that contains the
+     * information needed to draw the symbol on the map.
+     * DOES NOT support RADARC, CAKE, TRACK etc...
+     * ArrayList&lt;Point2D&gt; milStdSymbol.getSymbolShapes[index].getPolylines()
+     * and 
+     * ShapeInfo = milStdSymbol.getModifierShapes[index]. 
+     * 
+     * 
+     * @param id
+     *            A unique identifier used to identify the symbol by Google map.
+     *            The id will be the folder name that contains the graphic.
+     * @param name
+     *            a string used to display to the user as the name of the
+     *            graphic being created.
+     * @param description
+     *            a brief description about the graphic being made and what it
+     *            represents.
+     * @param basicShapeType
+     *             {@link BasicShapes}
+     * @param controlPoints
+     *            The vertices of the graphics that make up the graphic. Passed
+     *            in the format of a string, using decimal degrees separating
+     *            lat and lon by a comma, separating coordinates by a space. The
+     *            following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
+     * @param altitudeMode
+     *            Indicates whether the symbol should interpret altitudes as
+     *            above sea level or above ground level. Options are
+     *            "clampToGround", "relativeToGround" (from surface of earth),
+     *            "absolute" (sea level), "relativeToSeaFloor" (from the bottom
+     *            of major bodies of water).
+     * @param scale
+     *            A number corresponding to how many meters one meter of our map
+     *            represents. A value "50000" would mean 1:50K which means for
+     *            every meter of our map it represents 50000 meters of real
+     *            world distance.
+     * @param bbox
+     *            The viewable area of the map. Passed in the format of a string
+     *            "lowerLeftX,lowerLeftY,upperRightX,upperRightY." Not required
+     *            but can speed up rendering in some cases. example:
+     *            "-50.4,23.6,-42.2,24.2"
+     * @param modifiers
+     *            Used like:
+     *            modifiers.set(Modifiers.T_UNIQUE_DESIGNATION_1, "T");
+     *            Or
+     *            modifiers.set(Modifiers.AM_DISTANCE, "1000,2000,3000");
+     * @param attributes
+     * 			  Used like:
+     *            attributes.set(MilStdAttributes.LineWidth, "3");
+     *            Or
+     *            attributes.set(MilStdAttributes.LineColor, "#00FF00");
+     * @return MilStdSymbol
+     */
+    public static RenderBasicShapeAsMilStdSymbol(id: string, name: string, description: string, basicShapeType: int,
+        controlPoints: string, altitudeMode: string, scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>): MilStdSymbol {
+        let mSymbol: MilStdSymbol;
+        try {
+                if (SymbolUtilities.isBasicShape(basicShapeType))
+            mSymbol = MultiPointHandler.RenderBasicShapeAsMilStdSymbol(id, name, description, basicShapeType,
+                controlPoints, scale, bbox, modifiers, attributes);
+        } catch (ea) {
+            if (ea instanceof Error) {
+                mSymbol = null;
+                ErrorLogger.LogException("WebRenderer", "RenderMultiPointAsMilStdSymbol" + " - " + basicShapeType, ea, LogLevel.WARNING);
+            } else {
+                throw ea;
+            }
+        }
 
+        return mSymbol;
+    }
+
+        /**
+     * Renders all multi-point symbols, creating KML that can be used to draw
+     * it on a Google map.  Multipoint symbols cannot be draw the same 
+     * at different scales. For instance, graphics with arrow heads will need to 
+     * redraw arrowheads when you zoom in on it.  Similarly, graphics like a 
+     * Forward Line of Troops drawn with half circles can improve performance if 
+     * clipped when the parts of the graphic that aren't on the screen.  To help 
+     * readjust graphics and increase performance, this function requires the 
+     * scale and bounding box to help calculate the new locations.
+     * @param id A unique identifier used to identify the symbol by Google map. 
+     * The id will be the folder name that contains the graphic.
+     * @param name a string used to display to the user as the name of the 
+     * graphic being created.
+     * @param description a brief description about the graphic being made and 
+     * what it represents.
+     * @param basicShapeType {@link BasicShapes}
+     * @param controlPoints The vertices of the graphics that make up the
+     * graphic.  Passed in the format of a string, using decimal degrees 
+     * separating lat and lon by a comma, separating coordinates by a space.  
+     * The following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
+     * @param altitudeMode Indicates whether the symbol should interpret 
+     * altitudes as above sea level or above ground level. Options are 
+     * "clampToGround", "relativeToGround" (from surface of earth), "absolute" 
+     * (sea level), "relativeToSeaFloor" (from the bottom of major bodies of 
+     * water).
+     * @param scale A number corresponding to how many meters one meter of our 
+     * map represents. A value "50000" would mean 1:50K which means for every 
+     * meter of our map it represents 50000 meters of real world distance.
+     * @param bbox The viewable area of the map.  Passed in the format of a
+     * string "lowerLeftX,lowerLeftY,upperRightX,upperRightY." Not required
+     * but can speed up rendering in some cases.
+     * example: "-50.4,23.6,-42.2,24.2"
+     * @param modifiers {@link Map}, keyed using constants from Modifiers.
+     * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
+     * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
+     * @param format An enumeration: 2 for GeoJSON.
+     * @return A JSON string representation of the graphic.
+     */
+    public static RenderBasicShape(id: string, name: string, description: string,
+        basicShapeType: int, controlPoints: string, altitudeMode: string,
+        scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>, format: int): string {
+        let output: string = "";
+        try {
+            JavaRendererUtilities.addAltModeToModifiersString(attributes, altitudeMode);
+            if (SymbolUtilities.isBasicShape(basicShapeType))
+                output = MultiPointHandler.RenderBasicShape(id, name, description, basicShapeType, controlPoints,
+                    scale, bbox, modifiers, attributes, format);
+        } catch (ea) {
+            if (ea instanceof Error) {
+                output = "{\"type\":'error',error:'There was an error creating the MilStdSymbol - " + ea.toString() + "'}";
+                ErrorLogger.LogException("WebRenderer", "RenderSymbol", ea, LogLevel.WARNING);
+            } else {
+                throw ea;
+            }
+        }
+
+        return output;
+    }
 
     /**
      * Given a symbol code meant for a single point symbol, returns the


### PR DESCRIPTION
- Adds support to render basic shapes through `WebRenderer.RenderBasicShapeAsMilStdSymbol()` and `WebRenderer.RenderBasicShape()`. Method arguments match `RenderMultiPointAsMilStdSymbol()` and `RenderSymbol()`
- Basic shapes have no symbol code so they must use the basic shape render methods and a case from `BasicShapes` class