### PR TITLE
3D Multipoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 node_modules/
 dist/
 docs/

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ export { ShapeInfo } from "./src/main/ts/armyc2/c5isr/renderer/utilities/ShapeIn
 export { MilStdSymbol } from "./src/main/ts/armyc2/c5isr/renderer/utilities/MilStdSymbol";
 
 export { BasicShapes } from "./src/main/ts/armyc2/c5isr/JavaLineArray/BasicShapes"
+export { Basic3DShapes } from "./src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes"
 
 export type { IPointConversion } from "./src/main/ts/armyc2/c5isr/renderer/utilities/IPointConversion";
 export { PointConverter3D } from "./src/main/ts/armyc2/c5isr/renderer/utilities/PointConverter3D";

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -42,6 +42,9 @@ export class TacticalLines {
      */
     public static readonly BS_BBOX = 15000004;
 
+    public static readonly BS_3D_ROUTE = 16000001;
+    public static readonly BS_3D_TRACK = 16000002;
+
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;
     public static readonly DZ: number = 22135000;

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -42,12 +42,12 @@ export class TacticalLines {
      */
     public static readonly BS_BBOX = 15000004;
 
-    public static readonly BS_3D_ROUTE = 16000001;
-    public static readonly BS_3D_TRACK = 16000002;
+    public static readonly BS_ORBIT = 16000001;
+    public static readonly BS_3D_ROUTE = 16000002;
     public static readonly BS_3D_RADARC = 16000003;
-    public static readonly BS_3D_CAKE = 16000004;
-    public static readonly BS_ORBIT = 16000005;
-    public static readonly BS_POLYARC = 16000006;
+    public static readonly BS_POLYARC = 16000004;
+    public static readonly BS_3D_CAKE = 16000005;
+    public static readonly BS_3D_TRACK = 16000006;
 
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -44,6 +44,8 @@ export class TacticalLines {
 
     public static readonly BS_3D_ROUTE = 16000001;
     public static readonly BS_3D_TRACK = 16000002;
+    public static readonly BS_3D_RADARC = 16000003;
+    public static readonly BS_3D_CAKE = 16000004;
 
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -46,6 +46,7 @@ export class TacticalLines {
     public static readonly BS_3D_TRACK = 16000002;
     public static readonly BS_3D_RADARC = 16000003;
     public static readonly BS_3D_CAKE = 16000004;
+    public static readonly BS_ORBIT = 16000005;
 
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -43,11 +43,11 @@ export class TacticalLines {
     public static readonly BS_BBOX = 15000004;
 
     public static readonly BS_ORBIT = 16000001;
-    public static readonly BS_3D_ROUTE = 16000002;
-    public static readonly BS_3D_RADARC = 16000003;
+    public static readonly BS_ROUTE = 16000002;
+    public static readonly BS_RADARC = 16000003;
     public static readonly BS_POLYARC = 16000004;
-    public static readonly BS_3D_CAKE = 16000005;
-    public static readonly BS_3D_TRACK = 16000006;
+    public static readonly BS_CAKE = 16000005;
+    public static readonly BS_TRACK = 16000006;
 
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;
@@ -176,8 +176,8 @@ export class TacticalLines {
     public static readonly ASR_ONEWAY: number = 25330401;
     public static readonly ASR_ALT: number = 25330403;
     public static readonly ASR_TWOWAY: number = 25330402;
-    public static readonly ROUTE_ONEWAY: number = 25330501;
-    public static readonly ROUTE_ALT: number = 25330502;
+    public static readonly TRAFFIC_ROUTE_ONEWAY: number = 25330501;
+    public static readonly TRAFFIC_ROUTE_ALT: number = 25330502;
     public static readonly BEARING: number = 26400000;
     public static readonly BEARING_EW: number = 220101;
     public static readonly BEARING_J: number = 220107;
@@ -517,7 +517,7 @@ export class TacticalLines {
     public static readonly GENERIC_AREA: number = 25120700;
     public static readonly HOL: number = 25141800;
     public static readonly BHL: number = 2514190;
-    public static readonly ROUTE: number = 25330500;
+    public static readonly TRAFFIC_ROUTE: number = 25330500;
     public static readonly FPOL: number = 25344100;
     public static readonly RPOL: number = 25344200;
 

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/TacticalLines.ts
@@ -47,6 +47,7 @@ export class TacticalLines {
     public static readonly BS_3D_RADARC = 16000003;
     public static readonly BS_3D_CAKE = 16000004;
     public static readonly BS_ORBIT = 16000005;
+    public static readonly BS_POLYARC = 16000006;
 
     public static readonly PZ: number = 22138000;
     public static readonly LZ: number = 22137000;

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/arraysupport.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/arraysupport.ts
@@ -3366,8 +3366,8 @@ export class arraysupport {
                 case TacticalLines.ASR_ONEWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT: {
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT: {
                     nCounter = vblSaveCounter as int;
                     pLinePoints[vblSaveCounter - 1].style = 5;
                     for (j = 0; j < vblSaveCounter - 1; j++) {
@@ -3402,7 +3402,7 @@ export class arraysupport {
                             nCounter++;
                         }
 
-                        if (lineType === TacticalLines.MSR_ALT || lineType === TacticalLines.ASR_ALT || lineType === TacticalLines.ROUTE_ALT) {
+                        if (lineType === TacticalLines.MSR_ALT || lineType === TacticalLines.ASR_ALT || lineType === TacticalLines.TRAFFIC_ROUTE_ALT) {
                             lineutility.GetArrowHead4Double(pt3, pt2, d as int, d as int,
                                 pArrowPoints, 0);
 

--- a/src/main/ts/armyc2/c5isr/JavaLineArray/countsupport.ts
+++ b/src/main/ts/armyc2/c5isr/JavaLineArray/countsupport.ts
@@ -454,7 +454,7 @@ export class countsupport {
 
                 case TacticalLines.MSR_ALT:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE_ALT: {
+                case TacticalLines.TRAFFIC_ROUTE_ALT: {
                     count = vblCounter * 9;
                     break;
                 }
@@ -467,7 +467,7 @@ export class countsupport {
 
                 case TacticalLines.MSR_ONEWAY:
                 case TacticalLines.ASR_ONEWAY:
-                case TacticalLines.ROUTE_ONEWAY: {
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY: {
                     count = vblCounter * 6;
                     break;
                 }

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/Modifier2.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/Modifier2.ts
@@ -790,9 +790,9 @@ export class Modifier2 {
                     break;
                 }
 
-                case TacticalLines.ROUTE:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT: {
+                case TacticalLines.TRAFFIC_ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT: {
                     label = "ROUTE";
                     break;
                 }
@@ -2448,9 +2448,9 @@ export class Modifier2 {
                 case TacticalLines.ASR_ONEWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT:
+                case TacticalLines.TRAFFIC_ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT:
                 case TacticalLines.DHA_REVD:
                 case TacticalLines.DHA:
                 case TacticalLines.KILL_ZONE:
@@ -3303,12 +3303,12 @@ export class Modifier2 {
 
                 case TacticalLines.MSR_ONEWAY:
                 case TacticalLines.ASR_ONEWAY:
-                case TacticalLines.ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
                 case TacticalLines.MSR_TWOWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.MSR_ALT:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE_ALT: {
+                case TacticalLines.TRAFFIC_ROUTE_ALT: {
                     stringWidth = (1.5 * metrics.stringWidth(label + TSpace + tg.get_Name()) as double) as int;
                     let arrowOffset: double = 10 * DPIScaleFactor;
                     if (linetype === TacticalLines.MSR_TWOWAY || linetype === TacticalLines.ASR_TWOWAY) {
@@ -3316,7 +3316,7 @@ export class Modifier2 {
                         arrowOffset = 25 * DPIScaleFactor;
                     }
 
-                    let isAlt: boolean = linetype === TacticalLines.MSR_ALT || linetype === TacticalLines.ASR_ALT || linetype === TacticalLines.ROUTE_ALT;
+                    let isAlt: boolean = linetype === TacticalLines.MSR_ALT || linetype === TacticalLines.ASR_ALT || linetype === TacticalLines.TRAFFIC_ROUTE_ALT;
                     if (isAlt) {
                         stringWidth2 = (1.5 * metrics.stringWidth("ALT") as double) as int;
                         if (stringWidth2 > stringWidth) {
@@ -3470,7 +3470,7 @@ export class Modifier2 {
 
                 case TacticalLines.MSR:
                 case TacticalLines.ASR:
-                case TacticalLines.ROUTE: {
+                case TacticalLines.TRAFFIC_ROUTE: {
                     //AddIntegralModifier(tg, label + tg.get_Name(), aboveMiddle, -1*csFactor, middleSegment, middleSegment + 1,false);
                     foundSegment = false;
                     //acevedo - 11/30/2017 - adding option to render only 2 labels.

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -1373,7 +1373,8 @@ export class clsUtility {
                 case TacticalLines.TBA_RECTANGULAR:
                 case TacticalLines.TVAR_RECTANGULAR:
                 case TacticalLines.KILLBOXBLUE_RECTANGULAR:
-                case TacticalLines.KILLBOXPURPLE_RECTANGULAR: {
+                case TacticalLines.KILLBOXPURPLE_RECTANGULAR:
+                case TacticalLines.BS_ORBIT: {
                     return true;
                 }
 

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -834,6 +834,8 @@ export class clsUtility {
                                 case TacticalLines.RANGE_FAN:
                                 case TacticalLines.RANGE_FAN_SECTOR:
                                 case TacticalLines.RADAR_SEARCH:
+                                case TacticalLines.BS_3D_RADARC:
+                                case TacticalLines.BS_3D_CAKE:
                                 case TacticalLines.BBS_AREA:
                                 case TacticalLines.BBS_RECTANGLE: {
                                     shape.setFillColor(null);
@@ -1348,6 +1350,8 @@ export class clsUtility {
                 case TacticalLines.RANGE_FAN_FILL:
                 case TacticalLines.RANGE_FAN_SECTOR:
                 case TacticalLines.RADAR_SEARCH:
+                case TacticalLines.BS_3D_RADARC:
+                case TacticalLines.BS_3D_CAKE:
                 case TacticalLines.PAA_RECTANGULAR:
                 case TacticalLines.RECTANGULAR_TARGET:
                 case TacticalLines.FSA_RECTANGULAR:

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -1353,6 +1353,8 @@ export class clsUtility {
                 case TacticalLines.FSA_RECTANGULAR:
                 case TacticalLines.SHIP_AOI_RECTANGULAR:
                 case TacticalLines.DEFENDED_AREA_RECTANGULAR:
+                case TacticalLines.BS_3D_ROUTE:
+                case TacticalLines.BS_3D_TRACK:
                 case TacticalLines.FFA_RECTANGULAR:
                 case TacticalLines.RFA_RECTANGULAR:
                 case TacticalLines.NFA_RECTANGULAR:

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -834,8 +834,8 @@ export class clsUtility {
                                 case TacticalLines.RANGE_FAN:
                                 case TacticalLines.RANGE_FAN_SECTOR:
                                 case TacticalLines.RADAR_SEARCH:
-                                case TacticalLines.BS_3D_RADARC:
-                                case TacticalLines.BS_3D_CAKE:
+                                case TacticalLines.BS_RADARC:
+                                case TacticalLines.BS_CAKE:
                                 case TacticalLines.BBS_AREA:
                                 case TacticalLines.BBS_RECTANGLE: {
                                     shape.setFillColor(null);
@@ -974,9 +974,9 @@ export class clsUtility {
                 case TacticalLines.ASR_ONEWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT: {
+                case TacticalLines.TRAFFIC_ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT: {
                     result = true;
                     break;
                 }
@@ -1350,15 +1350,15 @@ export class clsUtility {
                 case TacticalLines.RANGE_FAN_FILL:
                 case TacticalLines.RANGE_FAN_SECTOR:
                 case TacticalLines.RADAR_SEARCH:
-                case TacticalLines.BS_3D_RADARC:
-                case TacticalLines.BS_3D_CAKE:
+                case TacticalLines.BS_RADARC:
+                case TacticalLines.BS_CAKE:
                 case TacticalLines.PAA_RECTANGULAR:
                 case TacticalLines.RECTANGULAR_TARGET:
                 case TacticalLines.FSA_RECTANGULAR:
                 case TacticalLines.SHIP_AOI_RECTANGULAR:
                 case TacticalLines.DEFENDED_AREA_RECTANGULAR:
-                case TacticalLines.BS_3D_ROUTE:
-                case TacticalLines.BS_3D_TRACK:
+                case TacticalLines.BS_ROUTE:
+                case TacticalLines.BS_TRACK:
                 case TacticalLines.FFA_RECTANGULAR:
                 case TacticalLines.RFA_RECTANGULAR:
                 case TacticalLines.NFA_RECTANGULAR:
@@ -1718,8 +1718,8 @@ export class clsUtility {
                 case TacticalLines.ASR_ONEWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT:
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT:
                 case TacticalLines.ATWALL: {
                     break;
                 }
@@ -2187,7 +2187,7 @@ export class clsUtility {
             switch (linetype) {
                 case TacticalLines.MSR:
                 case TacticalLines.ASR:
-                case TacticalLines.ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE:
                 case TacticalLines.BOUNDARY: {
                     if (tg.get_H() == null || tg.get_H().length === 0) {
 
@@ -2239,7 +2239,7 @@ export class clsUtility {
             switch (linetype) {
                 case TacticalLines.MSR:
                 case TacticalLines.ASR:
-                case TacticalLines.ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE:
                 case TacticalLines.BOUNDARY: {
                     if (tg.get_H() == null || tg.get_H().length === 0) {
 
@@ -2305,7 +2305,7 @@ export class clsUtility {
             switch (linetype) {
                 case TacticalLines.ASR:
                 case TacticalLines.MSR:
-                case TacticalLines.ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE:
                 case TacticalLines.BOUNDARY: {
                     break;
                 }

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -1374,7 +1374,8 @@ export class clsUtility {
                 case TacticalLines.TVAR_RECTANGULAR:
                 case TacticalLines.KILLBOXBLUE_RECTANGULAR:
                 case TacticalLines.KILLBOXPURPLE_RECTANGULAR:
-                case TacticalLines.BS_ORBIT: {
+                case TacticalLines.BS_ORBIT:
+                case TacticalLines.BS_POLYARC: {
                     return true;
                 }
 

--- a/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/JavaTacticalRenderer/clsUtility.ts
@@ -834,8 +834,6 @@ export class clsUtility {
                                 case TacticalLines.RANGE_FAN:
                                 case TacticalLines.RANGE_FAN_SECTOR:
                                 case TacticalLines.RADAR_SEARCH:
-                                case TacticalLines.BS_RADARC:
-                                case TacticalLines.BS_CAKE:
                                 case TacticalLines.BBS_AREA:
                                 case TacticalLines.BBS_RECTANGLE: {
                                     shape.setFillColor(null);

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -361,6 +361,9 @@ export class clsRenderer {
             switch (lineType) {
                 case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BBS_POINT:
+                case TacticalLines.BS_3D_ROUTE:
+                case TacticalLines.BS_3D_TRACK:
+                case TacticalLines.BS_ORBIT:
                     let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
                     if (AM != null && AM.length > 0) {
                         let strAM: string = String(AM[0]);
@@ -374,6 +377,19 @@ export class clsRenderer {
                     break;
                 default:
                     break;
+            }
+            if (lineType === TacticalLines.BS_3D_TRACK) {
+                let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                if (AM != null) {
+                    let strAM: string = "";
+                    for (let j: int = 0; j < AM.length; j++) {
+                        strAM += AM[j].toString();
+                        if (j < AM.length - 1) {
+                            strAM += ",";
+                        }
+                    }
+                    tg.set_AM(strAM);
+                }
             }
             if (lineType == TacticalLines.PBS_RECTANGLE || lineType == TacticalLines.PBS_SQUARE) {
                 let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -346,7 +346,7 @@ export class clsRenderer {
                     tg.set_AN(strAN);
                 }
             }
-            if (lineType === TacticalLines.BS_3D_CAKE) {
+            if (lineType === TacticalLines.BS_CAKE) {
                 let AM: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
                 let AN: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
                 if (AM != null) {
@@ -396,7 +396,7 @@ export class clsRenderer {
                     tg.set_LRMM(strLeftRightMinMax);
                 }
             }
-            if (lineType === TacticalLines.BS_3D_RADARC) {
+            if (lineType === TacticalLines.BS_RADARC) {
                 let AM: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
                 let AN: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
                 if (AM != null) {
@@ -467,8 +467,8 @@ export class clsRenderer {
             switch (lineType) {
                 case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BBS_POINT:
-                case TacticalLines.BS_3D_ROUTE:
-                case TacticalLines.BS_3D_TRACK:
+                case TacticalLines.BS_ROUTE:
+                case TacticalLines.BS_TRACK:
                 case TacticalLines.BS_ORBIT:
                     let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
                     if (AM != null && AM.length > 0) {
@@ -484,7 +484,7 @@ export class clsRenderer {
                 default:
                     break;
             }
-            if (lineType === TacticalLines.BS_3D_TRACK) {
+            if (lineType === TacticalLines.BS_TRACK) {
                 let AM: Array<double> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
                 if (AM != null) {
                     let strAM: string = "";
@@ -1872,8 +1872,8 @@ export class clsRenderer {
                         case TacticalLines.RANGE_FAN:
                         case TacticalLines.RANGE_FAN_SECTOR:
                         case TacticalLines.RADAR_SEARCH:
-                        case TacticalLines.BS_3D_RADARC:
-                        case TacticalLines.BS_3D_CAKE: {
+                        case TacticalLines.BS_RADARC:
+                        case TacticalLines.BS_CAKE: {
                             if (tg.get_FillColor() == null || tg.get_FillColor().getAlpha() < 2) {
                                 break;
                             }
@@ -2354,8 +2354,8 @@ export class clsRenderer {
                             case TacticalLines.RANGE_FAN:
                             case TacticalLines.RANGE_FAN_SECTOR:
                             case TacticalLines.RADAR_SEARCH:
-                            case TacticalLines.BS_3D_RADARC:
-                            case TacticalLines.BS_3D_CAKE: {
+                            case TacticalLines.BS_RADARC:
+                            case TacticalLines.BS_CAKE: {
                                 if (tg.get_FillColor() == null || tg.get_FillColor().getAlpha() < 2) {
                                     break;
                                 }
@@ -2494,15 +2494,15 @@ export class clsRenderer {
                 }
 
                 case 330500: {
-                    return TacticalLines.ROUTE;
+                    return TacticalLines.TRAFFIC_ROUTE;
                 }
 
                 case 330501: {
-                    return TacticalLines.ROUTE_ONEWAY;
+                    return TacticalLines.TRAFFIC_ROUTE_ONEWAY;
                 }
 
                 case 330502: {
-                    return TacticalLines.ROUTE_ALT;
+                    return TacticalLines.TRAFFIC_ROUTE_ALT;
                 }
 
                 case 344100: {

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -1871,9 +1871,7 @@ export class clsRenderer {
                     switch (linetype) {
                         case TacticalLines.RANGE_FAN:
                         case TacticalLines.RANGE_FAN_SECTOR:
-                        case TacticalLines.RADAR_SEARCH:
-                        case TacticalLines.BS_RADARC:
-                        case TacticalLines.BS_CAKE: {
+                        case TacticalLines.RADAR_SEARCH: {
                             if (tg.get_FillColor() == null || tg.get_FillColor().getAlpha() < 2) {
                                 break;
                             }
@@ -2353,9 +2351,7 @@ export class clsRenderer {
                         switch (linetype) {
                             case TacticalLines.RANGE_FAN:
                             case TacticalLines.RANGE_FAN_SECTOR:
-                            case TacticalLines.RADAR_SEARCH:
-                            case TacticalLines.BS_RADARC:
-                            case TacticalLines.BS_CAKE: {
+                            case TacticalLines.RADAR_SEARCH: {
                                 if (tg.get_FillColor() == null || tg.get_FillColor().getAlpha() < 2) {
                                     break;
                                 }

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -346,6 +346,94 @@ export class clsRenderer {
                     tg.set_AN(strAN);
                 }
             }
+            if (lineType === TacticalLines.BS_3D_CAKE) {
+                let AM: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                let AN: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (AM != null) {
+                    let strAM: string = "";
+                    for (let j: int = 0; j < AM.length; j++) {
+                        strAM += AM[j].toString();
+                        if (j < AM.length - 1) {
+                            strAM += ",";
+                        }
+                    }
+                    tg.set_AM(strAM);
+                }
+                if (AN != null) {
+                    let strAN: string = "";
+                    for (let j: int = 0; j < AN.length; j++) {
+                        strAN += AN[j];
+                        if (j < AN.length - 1) {
+                            strAN += ",";
+                        }
+                    }
+                    tg.set_AN(strAN);
+                }
+                if (AM != null && AN != null) {
+                    let numSectors: int = AN.length / 2;
+                    let left: double = 0;
+                    let right: double = 0;
+                    let min: double = 0;
+                    let max: double = 0;
+                    //construct left,right,min,max from the arraylists
+                    let strLeftRightMinMax: string = "";
+                    for (let j: int = 0; j < numSectors; j++) {
+                        left = AN[2 * j];
+                        right = AN[2 * j + 1];
+                        min = AM[2 * j];
+                        max = AM[2 * j + 1];
+                        strLeftRightMinMax += left.toString() + "," + right.toString() + "," + min.toString() + "," + max.toString();
+                        if (j < numSectors - 1) {
+                            strLeftRightMinMax += ",";
+                        }
+
+                    }
+                    let len: int = strLeftRightMinMax.length;
+                    let c: string = strLeftRightMinMax.substring(len - 1, len);
+                    if (c === ",") {
+                        strLeftRightMinMax = strLeftRightMinMax.substring(0, len - 1);
+                    }
+                    tg.set_LRMM(strLeftRightMinMax);
+                }
+            }
+            if (lineType === TacticalLines.BS_3D_RADARC) {
+                let AM: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                let AN: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (AM != null) {
+                    let strAM: string = "";
+                    for (let j: int = 0; j < AM.length && j < 2; j++) {
+                        strAM += AM[j].toString();
+                        if (j < AM.length - 1) {
+                            strAM += ",";
+                        }
+                    }
+                    tg.set_AM(strAM);
+                }
+                if (AN != null) {
+                    let strAN: string = "";
+                    for (let j: int = 0; j < AN.length && j < 2; j++) {
+                        strAN += AN[j];
+                        if (j < AN.length - 1) {
+                            strAN += ",";
+                        }
+                    }
+                    tg.set_AN(strAN);
+                }
+                if (AM != null && AN != null) {
+                    let left: double = 0;
+                    let right: double = 0;
+                    let min: double = 0;
+                    let max: double = 0;
+                    //construct left,right,min,max from the arraylists
+                    let strLeftRightMinMax: string = "";
+                    left = AN[0];
+                    right = AN[1];
+                    min = AM[0];
+                    max = AM[1];
+                    strLeftRightMinMax += left.toString() + "," + right.toString() + "," + min.toString() + "," + max.toString();
+                    tg.set_LRMM(strLeftRightMinMax);
+                }
+            }
             switch (lineType) {
                 case TacticalLines.BBS_AREA:
                 case TacticalLines.BBS_LINE:
@@ -1765,7 +1853,9 @@ export class clsRenderer {
                     switch (linetype) {
                         case TacticalLines.RANGE_FAN:
                         case TacticalLines.RANGE_FAN_SECTOR:
-                        case TacticalLines.RADAR_SEARCH: {
+                        case TacticalLines.RADAR_SEARCH:
+                        case TacticalLines.BS_3D_RADARC:
+                        case TacticalLines.BS_3D_CAKE: {
                             if (tg.get_FillColor() == null || tg.get_FillColor().getAlpha() < 2) {
                                 break;
                             }
@@ -2245,7 +2335,9 @@ export class clsRenderer {
                         switch (linetype) {
                             case TacticalLines.RANGE_FAN:
                             case TacticalLines.RANGE_FAN_SECTOR:
-                            case TacticalLines.RADAR_SEARCH: {
+                            case TacticalLines.RADAR_SEARCH:
+                            case TacticalLines.BS_3D_RADARC:
+                            case TacticalLines.BS_3D_CAKE: {
                                 if (tg.get_FillColor() == null || tg.get_FillColor().getAlpha() < 2) {
                                     break;
                                 }

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer.ts
@@ -434,6 +434,24 @@ export class clsRenderer {
                     tg.set_LRMM(strLeftRightMinMax);
                 }
             }
+            if (lineType === TacticalLines.BS_POLYARC) {
+                let AM: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                let AN: Array<number> = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (AM != null && AM.length > 0) {
+                    let strAM: string = AM[0].toString();
+                    tg.set_AM(strAM);
+                }
+                if (AN != null) {
+                    let strAN: string = "";
+                    for (let j: int = 0; j < AN.length && j < 2; j++) {
+                        strAN += AN[j];
+                        if (j < AN.length - 1) {
+                            strAN += ",";
+                        }
+                    }
+                    tg.set_AN(strAN);
+                }                   
+            }
             switch (lineType) {
                 case TacticalLines.BBS_AREA:
                 case TacticalLines.BBS_LINE:

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer2.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsRenderer2.ts
@@ -42,7 +42,7 @@ export class clsRenderer2 {
         shapes: Array<Shape2>): void {
         try {
             let linetype: int = tg.get_LineType();
-            if (linetype !== TacticalLines.MSR && linetype !== TacticalLines.ASR && linetype !== TacticalLines.ROUTE) {
+            if (linetype !== TacticalLines.MSR && linetype !== TacticalLines.ASR && linetype !== TacticalLines.TRAFFIC_ROUTE) {
                 return;
             }
 
@@ -298,7 +298,7 @@ export class clsRenderer2 {
 
 
                     if (CELineArray.CIsChannel(lineType) === 0) {
-                        if (lineType === TacticalLines.ASR || lineType === TacticalLines.MSR || lineType === TacticalLines.ROUTE) {
+                        if (lineType === TacticalLines.ASR || lineType === TacticalLines.MSR || lineType === TacticalLines.TRAFFIC_ROUTE) {
                             clsRenderer2.getMSRShapes(tg, shapes);
                         }
                         else {
@@ -314,7 +314,7 @@ export class clsRenderer2 {
 
             //set CELineArray.shapes properties
             if (bolMeTOC <= 0) {
-                if (lineType !== TacticalLines.ASR && lineType !== TacticalLines.MSR && lineType !== TacticalLines.ROUTE) {
+                if (lineType !== TacticalLines.ASR && lineType !== TacticalLines.MSR && lineType !== TacticalLines.TRAFFIC_ROUTE) {
                     clsUtilityJTR.SetShapeProperties(tg, shapes);
                 }
 

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtility.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtility.ts
@@ -459,9 +459,9 @@ export class clsUtility {
             case TacticalLines.ASR_ONEWAY:
             case TacticalLines.ASR_TWOWAY:
             case TacticalLines.ASR_ALT:
-            case TacticalLines.ROUTE:
-            case TacticalLines.ROUTE_ONEWAY:
-            case TacticalLines.ROUTE_ALT:
+            case TacticalLines.TRAFFIC_ROUTE:
+            case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+            case TacticalLines.TRAFFIC_ROUTE_ALT:
             case TacticalLines.HCONVOY:
             case TacticalLines.CONVOY:
             case TacticalLines.MFP:
@@ -928,7 +928,7 @@ export class clsUtility {
                 case TacticalLines.BOUNDARY:
                 case TacticalLines.MSR:
                 case TacticalLines.ASR:
-                case TacticalLines.ROUTE: {
+                case TacticalLines.TRAFFIC_ROUTE: {
                     let strH: string = tg.get_H();
                     if (strH != null && strH.length > 0) {
                         let strs: string[] = strH.split(",");

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -453,7 +453,7 @@ export class clsUtilityCPOF {
                     break;
                 }
 
-                case TacticalLines.BS_3D_ROUTE: {
+                case TacticalLines.BS_ROUTE: {
                     let am = tg.get_AM().split(",");
                     while (am.length < tg.LatLongs.length - 1) {
                         am.push(am[am.length - 1]);
@@ -505,7 +505,7 @@ export class clsUtilityCPOF {
                     break;
                 }
 
-                case TacticalLines.BS_3D_TRACK: {
+                case TacticalLines.BS_TRACK: {
                     let am = tg.get_AM().split(",");
                     while (am.length < 2 * (tg.LatLongs.length - 1)) {
                         am.push(am[am.length - 1]);
@@ -908,7 +908,7 @@ export class clsUtilityCPOF {
                 if (currentPt.style === 5 || currentPt.style === 10) {
                     beginLine = true;
                     //unless there are doubled points with style=5
-                    if ((linetype === TacticalLines.RANGE_FAN_FILL || linetype === TacticalLines.BS_3D_ROUTE || linetype === TacticalLines.BS_3D_TRACK) && k < tg.Pixels.length - 1) {
+                    if ((linetype === TacticalLines.RANGE_FAN_FILL || linetype === TacticalLines.BS_ROUTE || linetype === TacticalLines.BS_TRACK) && k < tg.Pixels.length - 1) {
                         shapes.push(shape);
                         shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
                     }
@@ -1077,7 +1077,7 @@ export class clsUtilityCPOF {
             tg1.Pixels.push(tg.Pixels[1]);
             tg1.set_LineType(TacticalLines.RANGE_FAN_FILL);
 
-            if (tg.get_LineType() === TacticalLines.RANGE_FAN_SECTOR || tg.get_LineType() === TacticalLines.RADAR_SEARCH || tg.get_LineType() === TacticalLines.BS_3D_RADARC || tg.get_LineType() === TacticalLines.BS_3D_CAKE) {
+            if (tg.get_LineType() === TacticalLines.RANGE_FAN_SECTOR || tg.get_LineType() === TacticalLines.RADAR_SEARCH || tg.get_LineType() === TacticalLines.BS_RADARC || tg.get_LineType() === TacticalLines.BS_CAKE) {
                 tg1.set_LRMM(tg.get_LRMM());
                 return tg1;
             } else {
@@ -1738,8 +1738,8 @@ export class clsUtilityCPOF {
                 case TacticalLines.ASR_ONEWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT:
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT:
                 case TacticalLines.DHA_REVD:
                 case TacticalLines.DHA:
                 case TacticalLines.KILL_ZONE:
@@ -1756,7 +1756,7 @@ export class clsUtilityCPOF {
 
                 case TacticalLines.MSR: //post clip these so there are identical points regardless whether segment data is set 10-5-16
                 case TacticalLines.ASR:
-                case TacticalLines.ROUTE:
+                case TacticalLines.TRAFFIC_ROUTE:
                 case TacticalLines.BOUNDARY: {
                     return false;
                 }
@@ -1873,9 +1873,9 @@ export class clsUtilityCPOF {
             case TacticalLines.ASR_ONEWAY:
             case TacticalLines.ASR_TWOWAY:
             case TacticalLines.ASR_ALT:
-            case TacticalLines.ROUTE:
-            case TacticalLines.ROUTE_ONEWAY:
-            case TacticalLines.ROUTE_ALT: {
+            case TacticalLines.TRAFFIC_ROUTE:
+            case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+            case TacticalLines.TRAFFIC_ROUTE_ALT: {
                 //undo any fill
                 let shape: Shape2;
                 if (shapes != null && shapes.length > 0) {
@@ -2337,8 +2337,8 @@ export class clsUtilityCPOF {
                 case TacticalLines.ASR_ONEWAY:
                 case TacticalLines.ASR_TWOWAY:
                 case TacticalLines.ASR_ALT:
-                case TacticalLines.ROUTE_ONEWAY:
-                case TacticalLines.ROUTE_ALT: {
+                case TacticalLines.TRAFFIC_ROUTE_ONEWAY:
+                case TacticalLines.TRAFFIC_ROUTE_ALT: {
                     //added because of segment data 4-22-13
                     //removed from this case block since we now post-clip these because of segment color data 10-5-16
                     //                case TacticalLines.MSR:

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -951,7 +951,7 @@ export class clsUtilityCPOF {
             tg1.Pixels.push(tg.Pixels[1]);
             tg1.set_LineType(TacticalLines.RANGE_FAN_FILL);
 
-            if (tg.get_LineType() === TacticalLines.RANGE_FAN_SECTOR || tg.get_LineType() === TacticalLines.RADAR_SEARCH) {
+            if (tg.get_LineType() === TacticalLines.RANGE_FAN_SECTOR || tg.get_LineType() === TacticalLines.RADAR_SEARCH || tg.get_LineType() === TacticalLines.BS_3D_RADARC || tg.get_LineType() === TacticalLines.BS_3D_CAKE) {
                 tg1.set_LRMM(tg.get_LRMM());
                 return tg1;
             } else {

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -219,6 +219,16 @@ export class clsUtilityCPOF {
                     break;
                 }
 
+                case TacticalLines.BS_POLYARC: {
+                    if (SymbolUtilities.isNumber(tg.get_AM())) {
+                        length.value[0] = parseFloat(tg.get_AM());
+                    }
+                    let an = tg.get_AN().split(",");
+                    attitude.value[0] = parseFloat(an[0]);
+                    attitude.value[1] = parseFloat(an[1]);
+                    break;
+                }
+
                 default: {
                     break;
                 }
@@ -668,6 +678,30 @@ export class clsUtilityCPOF {
 
                 case TacticalLines.RANGE_FAN_FILL: {  //circular range fan calls Change1TacticalAreas twice
                     clsUtilityCPOF.GetSectorRangeFan(tg, converter);
+                    break;
+                }
+
+                case TacticalLines.BS_POLYARC: {
+                    let pPointsArc: Array<POINT2> = new Array();
+                    let pPoints: Array<POINT2> = new Array();
+                    pPoints.push(pt0);
+                    pPoints.push(mdlGeodesic.geodesic_coordinate(pt0, length.value[0], attitude.value[0]));
+                    pPoints.push(mdlGeodesic.geodesic_coordinate(pt0, length.value[0], attitude.value[1]));
+                    mdlGeodesic.GetGeodesicArc2(pPoints, pPointsArc);
+
+                    for (let i = 0; i < pPointsArc.length; i++) {
+                        ptTemp = new POINT2(pPointsArc[i]);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        tg.Pixels.push(ptTemp);
+                    }
+
+                    for (let i = 1; i < tg.LatLongs.length; i++) {
+                        ptTemp = new POINT2(tg.LatLongs[i]);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        tg.Pixels.push(ptTemp);
+                    }
+
+                    tg.Pixels.push(tg.Pixels[0]);
                     break;
                 }
 

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -411,6 +411,59 @@ export class clsUtilityCPOF {
                     break;
                 }
 
+                case TacticalLines.BS_3D_ROUTE:
+                case TacticalLines.BS_3D_TRACK: {
+                    let am = tg.get_AM().split(",");
+                    while (am.length < tg.LatLongs.length - 1) {
+                        am.push(am[am.length - 1]);
+                    }
+                    for (let i = 0; i < tg.LatLongs.length - 1; i++) {
+                        let a12: ref<number[]> = new ref();
+                        let a21: ref<number[]> = new ref();
+                        let pt0: POINT2 = tg.LatLongs[i];
+                        let pt1: POINT2 = tg.LatLongs[i + 1];
+                        width.value = new Array<number>(1);
+                        attitude.value = new Array<number>(1);
+
+                        mdlGeodesic.geodesic_distance(pt0, pt1, a12, a21);
+                        attitude.value[0] = a12.value[0];
+
+                        if (SymbolUtilities.isNumber(am[i])) {
+                            width.value[0] = parseFloat(am[i]);
+                        }
+
+                        //get the upper left corner                    
+                        pt00 = mdlGeodesic.geodesic_coordinate(pt0, width.value[0] / 2, attitude.value[0] - 90);
+                        pt00 = clsUtilityCPOF.PointLatLongToPixels(pt00, converter);
+
+                        pt00.style = 0;
+                        tg.Pixels.push(pt00);
+
+                        //second corner (clockwise from center)
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt0, width.value[0] / 2, attitude.value[0] + 90);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+
+                        //third corner (clockwise from center)
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width.value[0] / 2, attitude.value[0] + 90);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+
+                        //fourth corner (clockwise from center)
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width.value[0] / 2, attitude.value[0] - 90);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+
+                        pt00 = new POINT2(pt00);
+                        pt00.style = 5;
+                        tg.Pixels.push(pt00);
+                    }
+                    break;
+                }
+
                 case TacticalLines.RECTANGULAR_TARGET: {
                     let pts: POINT2[] = new Array<POINT2>(4); // 4 Corners
 
@@ -729,7 +782,7 @@ export class clsUtilityCPOF {
                 if (currentPt.style === 5 || currentPt.style === 10) {
                     beginLine = true;
                     //unless there are doubled points with style=5
-                    if (linetype === TacticalLines.RANGE_FAN_FILL && k < tg.Pixels.length - 1) {
+                    if ((linetype === TacticalLines.RANGE_FAN_FILL || linetype === TacticalLines.BS_3D_ROUTE || linetype === TacticalLines.BS_3D_TRACK) && k < tg.Pixels.length - 1) {
                         shapes.push(shape);
                         shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
                     }

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -726,7 +726,9 @@ export class clsUtilityCPOF {
                     break;
                 }
 
-                case TacticalLines.RADAR_SEARCH: {
+                case TacticalLines.RADAR_SEARCH:
+                case TacticalLines.BS_RADARC:
+                case TacticalLines.BS_CAKE: {
                     clsUtilityCPOF.GetSectorRangeFan(tg, converter);
                     break;
                 }
@@ -908,7 +910,7 @@ export class clsUtilityCPOF {
                 if (currentPt.style === 5 || currentPt.style === 10) {
                     beginLine = true;
                     //unless there are doubled points with style=5
-                    if ((linetype === TacticalLines.RANGE_FAN_FILL || linetype === TacticalLines.BS_ROUTE || linetype === TacticalLines.BS_TRACK) && k < tg.Pixels.length - 1) {
+                    if ((linetype === TacticalLines.RANGE_FAN_FILL || linetype === TacticalLines.BS_ROUTE || linetype === TacticalLines.BS_TRACK || linetype === TacticalLines.BS_CAKE) && k < tg.Pixels.length - 1) {
                         shapes.push(shape);
                         shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
                     }
@@ -1077,7 +1079,7 @@ export class clsUtilityCPOF {
             tg1.Pixels.push(tg.Pixels[1]);
             tg1.set_LineType(TacticalLines.RANGE_FAN_FILL);
 
-            if (tg.get_LineType() === TacticalLines.RANGE_FAN_SECTOR || tg.get_LineType() === TacticalLines.RADAR_SEARCH || tg.get_LineType() === TacticalLines.BS_RADARC || tg.get_LineType() === TacticalLines.BS_CAKE) {
+            if (tg.get_LineType() === TacticalLines.RANGE_FAN_SECTOR || tg.get_LineType() === TacticalLines.RADAR_SEARCH) {
                 tg1.set_LRMM(tg.get_LRMM());
                 return tg1;
             } else {

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -737,6 +737,11 @@ export class clsUtilityCPOF {
                 }
 
                 case TacticalLines.BS_POLYARC: {
+                    // Polyarc points should be counterclockwise 
+                    if (clsUtilityCPOF.CalculateSignedAreaOfPolygon(tg.LatLongs) < 0) {
+                        tg.LatLongs = [tg.LatLongs[0]].concat(tg.LatLongs.slice(1).reverse());
+                    }
+
                     let pPointsArc: Array<POINT2> = new Array();
                     let pPoints: Array<POINT2> = new Array();
                     pPoints.push(pt0);
@@ -2834,4 +2839,21 @@ export class clsUtilityCPOF {
         }
     }
 
+    /**
+     * Calculating the signed area will tell you which direction the points are going.  
+     * Negative = Clock-wise, Positive = counter clock-wise
+     * A = 1/2 * (x1*y2 - x2*y1 + x2*y3 - x3*y2 + ... + xn*y1 - x1*yn)
+     */
+    static CalculateSignedAreaOfPolygon(coords: POINT2[]): number {
+        var signedArea = 0;
+        const len = coords.length;
+        for (var i = 0; i < len; i++) {
+            const x1 = coords[i].getX();
+            const y1 = coords[i].getY();
+            const x2 = coords[(i + 1) % len].getX();
+            const y2 = coords[(i + 1) % len].getY();
+            signedArea += (x1 * y2 - x2 * y1);
+        }
+        return signedArea / 2;
+    }
 }

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -204,7 +204,8 @@ export class clsUtilityCPOF {
                 case TacticalLines.TVAR_RECTANGULAR:
                 case TacticalLines.KILLBOXBLUE_RECTANGULAR:
                 case TacticalLines.KILLBOXPURPLE_RECTANGULAR:
-                case TacticalLines.RECTANGULAR_TARGET: {
+                case TacticalLines.RECTANGULAR_TARGET:
+                case TacticalLines.BS_ORBIT: {
                     if (tg.LatLongs.length >= 2) {
                         //get the length and the attitude in mils
                         pt0 = tg.LatLongs[0];
@@ -408,6 +409,37 @@ export class clsUtilityCPOF {
                     tg.Pixels.push(ptTemp);
 
                     tg.Pixels.push(pt00);
+                    break;
+                }
+
+                case TacticalLines.BS_ORBIT: {
+                    ptTemp = mdlGeodesic.geodesic_coordinate(pt0, width.value[0] / 2, attitude.value[0] - 90);
+                    ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                    ptTemp.style = 0;
+                    tg.Pixels.push(ptTemp);
+
+                    ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width.value[0] / 2, attitude.value[0] - 90);
+                    pPoints = new Array<POINT2>(3);
+                    pPoints[0] = new POINT2(pt1);
+                    pPoints[1] = new POINT2(ptTemp);
+                    pPoints[2] = new POINT2(ptTemp);
+                    let pPoints2 = mdlGeodesic.GetGeodesicArc(pPoints);
+                    for (j = 0; j < pPoints2.length / 2; j++) {
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(pPoints2[j], converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+                    }
+
+                    ptTemp = mdlGeodesic.geodesic_coordinate(pt0, width.value[0] / 2, attitude.value[0] + 90);
+                    pPoints[0] = new POINT2(pt0);
+                    pPoints[1] = new POINT2(ptTemp);
+                    pPoints[2] = new POINT2(ptTemp);
+                    pPoints2 = mdlGeodesic.GetGeodesicArc(pPoints);
+                    for (j = 0; j < pPoints2.length / 2; j++) {
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(pPoints2[j], converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+                    }
                     break;
                 }
 

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -89,7 +89,7 @@ export class clsUtilityCPOF {
             let pt1: POINT2 = new POINT2(0, 0);
             radius.value = new Array<number>(1);
             width.value = new Array<number>(1);
-            attitude.value = new Array<number>(1);
+            attitude.value = new Array<number>(2);
             length.value = new Array<number>(1);
             switch (lineType) {
                 case TacticalLines.CIRCULAR:

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.ts
@@ -453,8 +453,7 @@ export class clsUtilityCPOF {
                     break;
                 }
 
-                case TacticalLines.BS_3D_ROUTE:
-                case TacticalLines.BS_3D_TRACK: {
+                case TacticalLines.BS_3D_ROUTE: {
                     let am = tg.get_AM().split(",");
                     while (am.length < tg.LatLongs.length - 1) {
                         am.push(am[am.length - 1]);
@@ -464,37 +463,93 @@ export class clsUtilityCPOF {
                         let a21: ref<number[]> = new ref();
                         let pt0: POINT2 = tg.LatLongs[i];
                         let pt1: POINT2 = tg.LatLongs[i + 1];
-                        width.value = new Array<number>(1);
-                        attitude.value = new Array<number>(1);
+                        let width: number;
+                        let attitude: number;
 
                         mdlGeodesic.geodesic_distance(pt0, pt1, a12, a21);
-                        attitude.value[0] = a12.value[0];
+                        attitude = a12.value[0];
 
                         if (SymbolUtilities.isNumber(am[i])) {
-                            width.value[0] = parseFloat(am[i]);
+                            width = parseFloat(am[i]);
                         }
 
                         //get the upper left corner                    
-                        pt00 = mdlGeodesic.geodesic_coordinate(pt0, width.value[0] / 2, attitude.value[0] - 90);
+                        pt00 = mdlGeodesic.geodesic_coordinate(pt0, width / 2, attitude - 90);
                         pt00 = clsUtilityCPOF.PointLatLongToPixels(pt00, converter);
 
                         pt00.style = 0;
                         tg.Pixels.push(pt00);
 
                         //second corner (clockwise from center)
-                        ptTemp = mdlGeodesic.geodesic_coordinate(pt0, width.value[0] / 2, attitude.value[0] + 90);
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt0, width / 2, attitude + 90);
                         ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
                         ptTemp.style = 0;
                         tg.Pixels.push(ptTemp);
 
                         //third corner (clockwise from center)
-                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width.value[0] / 2, attitude.value[0] + 90);
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width / 2, attitude + 90);
                         ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
                         ptTemp.style = 0;
                         tg.Pixels.push(ptTemp);
 
                         //fourth corner (clockwise from center)
-                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width.value[0] / 2, attitude.value[0] - 90);
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, width / 2, attitude - 90);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+
+                        pt00 = new POINT2(pt00);
+                        pt00.style = 5;
+                        tg.Pixels.push(pt00);
+                    }
+                    break;
+                }
+
+                case TacticalLines.BS_3D_TRACK: {
+                    let am = tg.get_AM().split(",");
+                    while (am.length < 2 * (tg.LatLongs.length - 1)) {
+                        am.push(am[am.length - 1]);
+                    }
+                    for (let i = 0; i < tg.LatLongs.length - 1; i++) {
+                        let a12: ref<number[]> = new ref();
+                        let a21: ref<number[]> = new ref();
+                        let pt0: POINT2 = tg.LatLongs[i];
+                        let pt1: POINT2 = tg.LatLongs[i + 1];
+                        let leftWidth: number;
+                        let rightWidth: number;
+                        let attitude: number;
+
+                        mdlGeodesic.geodesic_distance(pt0, pt1, a12, a21);
+                        attitude = a12.value[0];
+
+                        if (SymbolUtilities.isNumber(am[2 * i])) {
+                            leftWidth = parseFloat(am[2 * i]);
+                        }
+                        if (SymbolUtilities.isNumber(am[2 * i + 1])) {
+                            rightWidth = parseFloat(am[2 * i + 1]);
+                        }
+
+                        //get the upper left corner                    
+                        pt00 = mdlGeodesic.geodesic_coordinate(pt0, leftWidth, attitude - 90);
+                        pt00 = clsUtilityCPOF.PointLatLongToPixels(pt00, converter);
+
+                        pt00.style = 0;
+                        tg.Pixels.push(pt00);
+
+                        //second corner (clockwise from center)
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt0, rightWidth, attitude + 90);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+
+                        //third corner (clockwise from center)
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, rightWidth, attitude + 90);
+                        ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
+                        ptTemp.style = 0;
+                        tg.Pixels.push(ptTemp);
+
+                        //fourth corner (clockwise from center)
+                        ptTemp = mdlGeodesic.geodesic_coordinate(pt1, leftWidth, attitude - 90);
                         ptTemp = clsUtilityCPOF.PointLatLongToPixels(ptTemp, converter);
                         ptTemp.style = 0;
                         tg.Pixels.push(ptTemp);

--- a/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityGE.ts
+++ b/src/main/ts/armyc2/c5isr/RenderMultipoints/clsUtilityGE.ts
@@ -1309,7 +1309,7 @@ export class clsUtilityGE {
                 case TacticalLines.BOUNDARY:
                 case TacticalLines.MSR:
                 case TacticalLines.ASR:
-                case TacticalLines.ROUTE: {
+                case TacticalLines.TRAFFIC_ROUTE: {
                     break;
                 }
 

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/LogLevel.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/LogLevel.ts
@@ -108,4 +108,8 @@ export class LogLevel {
     getName(): string { 
         return this.name;
     }
+
+    toString(): string {
+        return this.name;
+    }
 }

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/MilStdSymbol.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/MilStdSymbol.ts
@@ -355,7 +355,7 @@ export class MilStdSymbol {
                 else if (modifier === (Modifiers.AM_DISTANCE)
                         || modifier === (Modifiers.AN_AZIMUTH)
                         || modifier === (Modifiers.X_ALTITUDE_DEPTH)) {
-                        let value: string | null = this.getModifier_AM_AN_X(modifier, index);
+                        let value: string = String(this.getModifier_AM_AN_X(modifier, index));
                         if (value != null && value !== "null" && value !== "") {
                             return value;
                         }
@@ -450,7 +450,7 @@ export class MilStdSymbol {
      * @param index {@link Integer} array location
      * @return {@link Double}
      */
-    public getModifier_AM_AN_X(modifier: string, index: int): string | null {
+    public getModifier_AM_AN_X(modifier: string, index: int): number | null {
         let modifiers: Array<number>;
         if (modifier === (Modifiers.AM_DISTANCE)) {
             modifiers = this._AM_Distance;
@@ -469,7 +469,7 @@ export class MilStdSymbol {
             let value: number = 0;
             value = modifiers[index];
             if (value != null) {
-                return value.toString();
+                return value;
             }
             else {
                 return null;

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
@@ -2076,7 +2076,8 @@ export class SymbolUtilities {
             case TacticalLines.BS_3D_TRACK:
             case TacticalLines.BS_3D_RADARC:
             case TacticalLines.BS_3D_CAKE:
-            case TacticalLines.BS_ORBIT: {
+            case TacticalLines.BS_ORBIT:
+            case TacticalLines.BS_POLYARC: {
                 return true;
             }
             default: {

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
@@ -2072,10 +2072,10 @@ export class SymbolUtilities {
             case TacticalLines.BBS_POINT:
             case TacticalLines.BBS_RECTANGLE:
             case TacticalLines.BS_BBOX:
-            case TacticalLines.BS_3D_ROUTE:
-            case TacticalLines.BS_3D_TRACK:
-            case TacticalLines.BS_3D_RADARC:
-            case TacticalLines.BS_3D_CAKE:
+            case TacticalLines.BS_ROUTE:
+            case TacticalLines.BS_TRACK:
+            case TacticalLines.BS_RADARC:
+            case TacticalLines.BS_CAKE:
             case TacticalLines.BS_ORBIT:
             case TacticalLines.BS_POLYARC: {
                 return true;

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
@@ -2075,7 +2075,8 @@ export class SymbolUtilities {
             case TacticalLines.BS_3D_ROUTE:
             case TacticalLines.BS_3D_TRACK:
             case TacticalLines.BS_3D_RADARC:
-            case TacticalLines.BS_3D_CAKE: {
+            case TacticalLines.BS_3D_CAKE:
+            case TacticalLines.BS_ORBIT: {
                 return true;
             }
             default: {

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
@@ -2073,7 +2073,9 @@ export class SymbolUtilities {
             case TacticalLines.BBS_RECTANGLE:
             case TacticalLines.BS_BBOX:
             case TacticalLines.BS_3D_ROUTE:
-            case TacticalLines.BS_3D_TRACK: {
+            case TacticalLines.BS_3D_TRACK:
+            case TacticalLines.BS_3D_RADARC:
+            case TacticalLines.BS_3D_CAKE: {
                 return true;
             }
             default: {

--- a/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts
@@ -2071,7 +2071,9 @@ export class SymbolUtilities {
             case TacticalLines.BBS_LINE:
             case TacticalLines.BBS_POINT:
             case TacticalLines.BBS_RECTANGLE:
-            case TacticalLines.BS_BBOX: {
+            case TacticalLines.BS_BBOX:
+            case TacticalLines.BS_3D_ROUTE:
+            case TacticalLines.BS_3D_TRACK: {
                 return true;
             }
             default: {

--- a/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
@@ -769,7 +769,7 @@ export class MultiPointHandler {
                 if(textColor==null)
                     textColor=mSymbol.getLineColor();
 
-                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, mSymbol.get_WasClipped());
                 jsonOutput += jsonContent;
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
                 /*
@@ -1371,7 +1371,7 @@ export class MultiPointHandler {
                 if(textColor==null)
                     textColor=mSymbol.getLineColor();
 
-                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, mSymbol.get_WasClipped());
                 jsonOutput += jsonContent;
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
                 jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
@@ -1909,28 +1909,29 @@ export class MultiPointHandler {
 
     }
 
-    private static KMLize(id: string, name: string,
+    private static KMLize(id: string, 
+        name: string,
         description: string,
         symbolCode: string,
         shapes: Array<ShapeInfo>,
         modifiers: Array<ShapeInfo>,
         ipc: IPointConversion,
-        normalize: boolean, textColor: Color): string {
-
+        normalize: boolean,
+        textColor: Color,
+        wasClipped: boolean): string {
         let kml: string = "";
-
         let tempModifier: ShapeInfo;
-
-        let cdataStart: string = "<![CDATA[";
-        let cdataEnd: string = "]]>";
-
         let len: int = shapes.length;
         kml += ("<Folder id=\"" + id + "\">");
-        kml += ("<name>" + cdataStart + name + cdataEnd + "</name>");
+        kml += ("<name>" + name + "</name>");
         kml += ("<visibility>1</visibility>");
+        kml += ("<description>" + description + "</description>");
+        kml += ("<ExtendedData>");
+        kml += ("<Data name=\"symbolID\"><value>" + symbolCode + "</value></Data>");
+        kml += ("<Data name=\"wasClipped\"><value>" + wasClipped + "</value></Data>");
+        kml += ("</ExtendedData>");
         for (let i: int = 0; i < len; i++) {
-
-            let shapesToAdd: string = MultiPointHandler.ShapeToKMLString(name, description, symbolCode, shapes[i], ipc, normalize);
+            let shapesToAdd: string = MultiPointHandler.ShapeToKMLString(shapes[i], ipc, normalize);
             kml += (shapesToAdd);
         }
 
@@ -2501,33 +2502,18 @@ export class MultiPointHandler {
         return false;
     }
 
-    private static ShapeToKMLString(name: string,
-        description: string,
-        symbolCode: string,
-        shapeInfo: ShapeInfo,
+    private static ShapeToKMLString(shapeInfo: ShapeInfo,
         ipc: IPointConversion,
         normalize: boolean): string {
-
         let kml: string = "";
-
         let lineColor: Color;
         let fillColor: Color;
         let googleLineColor: string;
         let googleFillColor: string;
-
-        //String lineStyleId = "lineColor";
-
         let stroke: BasicStroke;
         let lineWidth: int = 4;
 
-        symbolCode = JavaRendererUtilities.normalizeSymbolCode(symbolCode);
-
-        let cdataStart: string = "<![CDATA[";
-        let cdataEnd: string = "]]>";
-
-        kml += ("<Placemark>");//("<Placemark id=\"" + id + "_mg" + "\">");
-        kml += ("<description>" + cdataStart + "<b>" + name + "</b><br/>" + "\n" + description + cdataEnd + "</description>");
-        //kml += ("<Style id=\"" + lineStyleId + "\">");
+        kml += ("<Placemark>");
         kml += ("<Style>");
 
         lineColor = shapeInfo.getLineColor();
@@ -2628,27 +2614,7 @@ export class MultiPointHandler {
                 kml += ("<altitudeMode>clampToGround</altitudeMode>");
                 kml += ("<tessellate>1</tessellate>");
                 kml += ("<coordinates>");
-
-                //this section is a workaround for a google earth bug. Issue 417 was closed
-                //for linestrings but they did not fix the smae issue for fills. If Google fixes the issue
-                //for fills then this section will need to be commented or it will induce an error.
-                let lastLongitude: double = Number.MIN_VALUE;
-                if (normalize === false && MultiPointHandler.IsOnePointSymbolCode(symbolCode)) {
-                    let n: int = shape.length;
-                    //for (int j = 0; j < shape.length; j++) 
-                    for (let j: int = 0; j < n; j++) {
-                        let coord: Point2D = shape[j] as Point2D;
-                        let geoCoord: Point2D = ipc.PixelsToGeo(coord);
-                        let longitude: double = geoCoord.getX();
-                        if (lastLongitude !== Number.MIN_VALUE) {
-                            if (Math.abs(longitude - lastLongitude) > 180) {
-                                normalize = true;
-                                break;
-                            }
-                        }
-                        lastLongitude = longitude;
-                    }
-                }
+                
                 let n: int = shape.length;
                 //for (int j = 0; j < shape.length; j++) 
                 for (let j: int = 0; j < n; j++) {
@@ -3714,7 +3680,7 @@ export class MultiPointHandler {
                 if(textColor==null)
                     textColor=mSymbol.getLineColor();
 
-                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, mSymbol.get_WasClipped());
                 jsonOutput += jsonContent;
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
                 /*

--- a/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
@@ -3771,7 +3771,7 @@ export class MultiPointHandler {
                 jsonOutput += (st);
                 jsonOutput += ("\"}");
 
-                ErrorLogger.LogException("MultiPointHandler", "RenderBasicSymbol", exc);
+                ErrorLogger.LogException("MultiPointHandler", "RenderBasicShape", exc);
             } else {
                 throw exc;
             }

--- a/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/MultiPointHandler.ts
@@ -213,7 +213,7 @@ export class MultiPointHandler {
      * @return the upper left corner of the MBR containing the geographic
      * coordinates
      */
-    private static getGeoUL(geoCoords: Array<Point2D>): Point2D {
+    static getGeoUL(geoCoords: Array<Point2D>): Point2D {
         let ptGeo: Point2D;
         try {
             let j: int = 0;
@@ -266,7 +266,7 @@ export class MultiPointHandler {
         }
         return ptGeo;
     }
-    private static getBboxFromCoords(geoCoords: Array<Point2D>): string {
+    static getBboxFromCoords(geoCoords: Array<Point2D>): string {
         //var ptGeo = null;
         let bbox: string;
         try {
@@ -323,7 +323,7 @@ export class MultiPointHandler {
         return bbox;
     }
 
-    private static crossesIDL(geoCoords: Array<Point2D>): boolean {
+    static crossesIDL(geoCoords: Array<Point2D>): boolean {
         let result: boolean = false;
         let pt2d: Point2D = MultiPointHandler.getControlPoint(geoCoords);
         let left: double = pt2d.getX();
@@ -463,7 +463,7 @@ export class MultiPointHandler {
      * @param origScale
      * @return
      */
-    private static getReasonableScale(bbox: string, origScale: double): double {
+    static getReasonableScale(bbox: string, origScale: double): double {
         try {
             let bounds: string[] = bbox.split(",");
             let left: double = parseFloat(bounds[0]);
@@ -1626,7 +1626,7 @@ export class MultiPointHandler {
      * @param symbol An existing MilStdSymbol
      * @return
      */
-    private static populateModifiers(saModifiers: Map<string, string>, saAttributes: Map<string, string>, symbol: MilStdSymbol): boolean {
+    static populateModifiers(saModifiers: Map<string, string>, saAttributes: Map<string, string>, symbol: MilStdSymbol): boolean {
         let modifiers: Map<string, string> = new Map();
         let attributes: Map<string, string> = saAttributes;
 
@@ -2018,7 +2018,7 @@ export class MultiPointHandler {
         return jstr;
     }
 
-    private static getIdealTextBackgroundColor(fgColor: Color): Color {
+    static getIdealTextBackgroundColor(fgColor: Color): Color {
         //ErrorLogger.LogMessage("SymbolDraw","getIdealtextBGColor", "in function", Level.SEVERE);
         try {
             //an array of three elements containing the
@@ -2460,7 +2460,7 @@ export class MultiPointHandler {
 
     }
 
-    private static normalizePoints(shape: Array<Point2D>, ipc: IPointConversion): boolean {
+    static normalizePoints(shape: Array<Point2D>, ipc: IPointConversion): boolean {
         let geoCoords: Point2D[] = new Array();
         let n: int = shape.length;
         //for (int j = 0; j < shape.length; j++) 
@@ -2477,6 +2477,9 @@ export class MultiPointHandler {
         return normalize;
     }
 
+    /**
+     * @deprecated
+     */
     private static IsOnePointSymbolCode(symbolCode: string): boolean {
         let basicCode: string = SymbolUtilities.getBasicSymbolID(symbolCode);
         //TODO: Revisit for basic shapes

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -1,0 +1,1054 @@
+import { MultiPointHandler } from "./MultiPointHandler";
+import { POINT2 } from "../../JavaLineArray/POINT2";
+import { TGLight } from "../../JavaTacticalRenderer/TGLight";
+import { clsRenderer } from "../../RenderMultipoints/clsRenderer";
+import { Point2D } from "../../graphics2d/Point2D";
+import { Rectangle } from "../../graphics2d/Rectangle";
+import { Color } from "../../renderer/utilities/Color";
+import { DrawRules } from "../../renderer/utilities/DrawRules";
+import { ErrorLogger } from "../../renderer/utilities/ErrorLogger";
+import { IPointConversion } from "../../renderer/utilities/IPointConversion";
+import { LogLevel } from "../../renderer/utilities/LogLevel";
+import { MSLookup } from "../../renderer/utilities/MSLookup";
+import { MilStdAttributes } from "../../renderer/utilities/MilStdAttributes";
+import { MilStdSymbol } from "../../renderer/utilities/MilStdSymbol";
+import { RendererSettings } from "../../renderer/utilities/RendererSettings";
+import { RendererUtilities } from "../../renderer/utilities/RendererUtilities";
+import { PointConverter } from "./PointConverter";
+import { JavaRendererUtilities } from "./utilities/JavaRendererUtilities";
+import { WebRenderer } from "./WebRenderer";
+import { type int, type double } from "../../graphics2d/BasicTypes";
+import { BasicStroke } from "../../graphics2d/BasicStroke";
+import { ShapeInfo } from "../../renderer/utilities/ShapeInfo";
+import { Font } from "../../graphics2d/Font";
+
+export class Shape3DHandler {
+    /**
+     * 3D version of {@link MultiPointHandler.RenderSymbol()}
+     */
+    public static RenderMilStd3dSymbol(id: string,
+        name: string,
+        description: string,
+        symbolCode: string,
+        controlPoints: string,
+        altitudeMode: string,
+        scale: number,
+        bbox: string,
+        symbolModifiers: Map<string, string>,
+        symbolAttributes: Map<string, string>,
+        format: int): string//,
+    {
+        //console.log("MultiPointHandler.RenderSymbol()");
+        let normalize: boolean = true;
+        //Double controlLat = 0.0;
+        //Double controlLong = 0.0;
+        //Double metPerPix = GeoPixelConversion.metersPerPixel(scale);
+        //String bbox2=getBoundingRectangle(controlPoints,bbox);
+        let jsonOutput: string = "";
+        let jsonContent: string = "";
+
+        let rect: Rectangle;
+        let coordinates: string[] = controlPoints.split(" ");
+        let tgl: TGLight = new TGLight();
+        let shapes: Array<ShapeInfo> = new Array<ShapeInfo>();
+        let modifiers: Array<ShapeInfo> = new Array<ShapeInfo>();
+        //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
+        let geoCoords: Array<Point2D> = new Array<Point2D>();
+        let len: int = coordinates.length;
+        //diagnostic create geoCoords here
+        let coordsUL: Point2D = null;
+
+        let symbolIsValid: string = MultiPointHandler.canRenderMultiPoint(symbolCode, symbolModifiers, len);
+        if (symbolIsValid !== "true") {
+            let ErrorOutput: string = "";
+            ErrorOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + " - ID: " + id + " - ");
+            ErrorOutput += symbolIsValid; //reason for error
+            ErrorOutput += ("\"}");
+            ErrorLogger.LogMessage("MultiPointHandler", "RenderSymbol", symbolIsValid, LogLevel.FINE);
+            return ErrorOutput;
+        }
+
+        if (MSLookup.getInstance().getMSLInfo(symbolCode).getDrawRule() != DrawRules.AREA10) // AREA10 can support infinite points
+            len = Math.min(len, MSLookup.getInstance().getMSLInfo(symbolCode).getMaxPointCount());
+        for (let i: int = 0; i < len; i++) {
+            let coordPair: string[] = coordinates[i].split(",");
+            let latitude: number = parseFloat(coordPair[1].trim());
+            let longitude: number = parseFloat(coordPair[0].trim());
+            geoCoords.push(new Point2D(longitude, latitude));
+        }
+        let tgPoints: Array<POINT2>;
+        let ipc: IPointConversion;
+
+        //Deutch moved section 6-29-11
+        let left: number = 0.0;
+        let right: number = 0.0;
+        let top: number = 0.0;
+        let bottom: number = 0.0;
+        let temp: Point2D;
+        let ptGeoUL: Point2D;
+        let width: int = 0;
+        let height: int = 0;
+        let leftX: int = 0;
+        let topY: int = 0;
+        let bottomY: int = 0;
+        let rightX: int = 0;
+        let j: int = 0;
+        let bboxCoords: Array<Point2D>;
+        if (bbox != null && bbox !== "") {
+            let bounds: string[];
+            if (bbox.includes(" "))//trapezoid
+            {
+                bboxCoords = new Array<Point2D>();
+                let x: double = 0;
+                let y: double = 0;
+                let coords: string[] = bbox.split(" ");
+                let arrCoord: string[];
+                for (let coord of coords) {
+                    arrCoord = coord.split(",");
+                    x = parseFloat(arrCoord[0]);
+                    y = parseFloat(arrCoord[1]);
+                    bboxCoords.push(new Point2D(x, y));
+                }
+                //use the upper left corner of the MBR containing geoCoords
+                //to set the converter
+                ptGeoUL = MultiPointHandler.getGeoUL(bboxCoords);
+                left = ptGeoUL.getX();
+                top = ptGeoUL.getY();
+                let bbox2: string = MultiPointHandler.getBboxFromCoords(bboxCoords);
+                scale = MultiPointHandler.getReasonableScale(bbox2, scale);
+                ipc = new PointConverter(left, top, scale);
+                let ptPixels: Point2D;
+                let ptGeo: Point2D;
+                let n: int = bboxCoords.length;
+                //for (j = 0; j < bboxCoords.length; j++) 
+                for (j = 0; j < n; j++) {
+                    ptGeo = bboxCoords[j];
+                    ptPixels = ipc.GeoToPixels(ptGeo);
+                    x = ptPixels.getX();
+                    y = ptPixels.getY();
+                    if (x < 20) {
+                        x = 20;
+                    }
+                    if (y < 20) {
+                        y = 20;
+                    }
+                    ptPixels.setLocation(x, y);
+                    //end section
+                    bboxCoords[j] = ptPixels;
+                }
+            } else//rectangle
+            {
+                bounds = bbox.split(",");
+                left = parseFloat(bounds[0]);
+                right = parseFloat(bounds[2]);
+                top = parseFloat(bounds[3]);
+                bottom = parseFloat(bounds[1]);
+                scale = MultiPointHandler.getReasonableScale(bbox, scale);
+                ipc = new PointConverter(left, top, scale);
+            }
+
+            let pt2d: Point2D;
+            if (bboxCoords == null) {
+                pt2d = new Point2D(left, top);
+                temp = ipc.GeoToPixels(pt2d);
+
+                leftX = temp.getX() as int;
+                topY = temp.getY() as int;
+
+                pt2d = new Point2D(right, bottom);
+                temp = ipc.GeoToPixels(pt2d);
+
+                bottomY = temp.getY() as int;
+                rightX = temp.getX() as int;
+                //diagnostic clipping does not work at large scales
+                //                if(scale>10e6)
+                //                {
+                //                    //diagnostic replace above by using a new ipc based on the coordinates MBR
+                //                    coordsUL=getGeoUL(geoCoords);
+                //                    temp = ipc.GeoToPixels(coordsUL);
+                //                    left=coordsUL.getX();
+                //                    top=coordsUL.getY();
+                //                    //shift the ipc to coordsUL origin so that conversions will be more accurate for large scales.
+                //                    ipc = new PointConverter(left, top, scale);
+                //                    //shift the rect to compenstate for the shifted ipc so that we can maintain the original clipping area.
+                //                    leftX -= (int)temp.getX();
+                //                    rightX -= (int)temp.getX();
+                //                    topY -= (int)temp.getY();
+                //                    bottomY -= (int)temp.getY();
+                //                    //end diagnostic
+                //                }
+                //end section
+
+                width = Math.abs(rightX - leftX) as int;
+                height = Math.abs(bottomY - topY) as int;
+
+                rect = new Rectangle(leftX, topY, width, height);
+            }
+        } else {
+            rect = null;
+        }
+        //end section
+
+        //        for (int i = 0; i < len; i++) {
+        //            String[] coordPair = coordinates[i].split(",");
+        //            Double latitude = Double.valueOf(coordPair[1].trim());
+        //            Double longitude = Double.valueOf(coordPair[0].trim());
+        //            geoCoords.push(new Point2D(longitude, latitude));
+        //        }
+        if (ipc == null) {
+            let ptCoordsUL: Point2D = MultiPointHandler.getGeoUL(geoCoords);
+            ipc = new PointConverter(ptCoordsUL.getX(), ptCoordsUL.getY(), scale);
+        }
+        //if (crossesIDL(geoCoords) == true) 
+        //        if(Math.abs(right-left)>180)
+        //        {
+        //            normalize = true;
+        //            ((PointConverter)ipc).set_normalize(true);
+        //        } 
+        //        else {
+        //            normalize = false;
+        //            ((PointConverter)ipc).set_normalize(false);
+        //        }
+
+        //seems to work ok at world view
+        //        if (normalize) {
+        //            NormalizeGECoordsToGEExtents(0, 360, geoCoords);
+        //        }
+
+        //M. Deutch 10-3-11
+        //must shift the rect pixels to synch with the new ipc
+        //the old ipc was in synch with the bbox, so rect x,y was always 0,0
+        //the new ipc synchs with the upper left of the geocoords so the boox is shifted
+        //and therefore the clipping rectangle must shift by the delta x,y between
+        //the upper left corner of the original bbox and the upper left corner of the geocoords
+        let geoCoords2: Array<Point2D> = new Array<Point2D>();
+        geoCoords2.push(new Point2D(left, top));
+        geoCoords2.push(new Point2D(right, bottom));
+
+        //        if (normalize) {
+        //            NormalizeGECoordsToGEExtents(0, 360, geoCoords2);
+        //        }
+
+        //disable clipping
+        if (MultiPointHandler.ShouldClipSymbol(symbolCode) === false) {
+
+            if (MultiPointHandler.crossesIDL(geoCoords) === false) {
+                rect = null;
+                bboxCoords = null;
+            }
+        }
+
+
+        tgl.set_SymbolId(symbolCode);// "GFGPSLA---****X" AMBUSH symbol code
+        tgl.set_Pixels(null);
+
+        try {
+
+            //String fillColor = null;
+            let mSymbol: MilStdSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
+            
+            if (format == WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                // Use dash array and hatch pattern fill for SVG output
+                symbolAttributes.set(MilStdAttributes.UseDashArray, 'true')
+                symbolAttributes.set(MilStdAttributes.UsePatternFill, "true")
+            }
+
+            if (symbolModifiers != null || symbolAttributes != null) {
+                MultiPointHandler.populateModifiers(symbolModifiers, symbolAttributes, mSymbol);
+            } else {
+                mSymbol.setFillColor(null);
+            }
+
+            if (bboxCoords == null) {
+                clsRenderer.renderWithPolylines(mSymbol, ipc, rect);
+            } else {
+                clsRenderer.renderWithPolylines(mSymbol, ipc, bboxCoords);
+            }
+
+            shapes = mSymbol.getSymbolShapes();
+            modifiers = mSymbol.getModifierShapes();
+
+            if (format === WebRenderer.OUTPUT_FORMAT_JSON) {
+                jsonOutput += ("{\"type\":\"symbol\",");
+                jsonContent = MultiPointHandler.JSONize(shapes, modifiers, ipc, true, normalize);
+                jsonOutput += (jsonContent);
+                jsonOutput += ("}");
+            } else if (format === WebRenderer.OUTPUT_FORMAT_KML) {
+                var textColor = mSymbol.getTextColor();
+                if(textColor==null)
+                    textColor=mSymbol.getLineColor();
+
+                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonOutput += jsonContent;
+            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
+                /*
+                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput += (jsonContent);
+                jsonOutput += (",\"properties\":{\"id\":\"");
+                jsonOutput += (id);
+                jsonOutput += ("\",\"name\":\"");
+                jsonOutput += (name);
+                jsonOutput += ("\",\"description\":\"");
+                jsonOutput += (description);
+                jsonOutput += ("\",\"symbolID\":\"");
+                jsonOutput += (symbolCode);
+                jsonOutput += ("\",\"wasClipped\":\"");
+                jsonOutput += (mSymbol.get_WasClipped()).toString();
+                jsonOutput += ("\"}}");         */
+
+                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = MultiPointHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput += (jsonContent);
+
+                //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
+                jsonOutput = jsonOutput.slice(0, -1);
+                if (jsonContent.length > 2)
+                    jsonOutput += ","
+                jsonOutput += ("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+
+                jsonOutput += (",\"properties\":{\"id\":\"");
+                jsonOutput += (id);
+                jsonOutput += ("\",\"name\":\"");
+                jsonOutput += (name);
+                jsonOutput += ("\",\"description\":\"");
+                jsonOutput += (description);
+                jsonOutput += ("\",\"symbolID\":\"");
+                jsonOutput += (symbolCode);
+                jsonOutput += ("\",\"wasClipped\":\"");
+                jsonOutput += (mSymbol.get_WasClipped()).toString();
+                //jsonOutput += ("\"}}");
+
+                jsonOutput += ("\"}}]}");
+            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                let textColor = mSymbol.getTextColor() ? mSymbol.getTextColor().toHexString(false) : "";
+                let backgroundColor = mSymbol.getTextBackgroundColor() ? mSymbol.getTextBackgroundColor().toHexString(false) : "";
+                //returns an svg with a geoTL and geoBR value to use to place the canvas on the map
+                jsonOutput = MultiPointHandlerSVG.GeoSVGize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, backgroundColor, mSymbol.get_WasClipped());
+            }
+        } catch (exc) {
+            if (exc instanceof Error) {
+                let st: string = JavaRendererUtilities.getStackTrace(exc);
+                jsonOutput = "";
+                jsonOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + ": " + "- ");
+                jsonOutput += (exc.message + " - ");
+                jsonOutput += (st);
+                jsonOutput += ("\"}");
+
+                ErrorLogger.LogException("MultiPointHandler", "RenderSymbol", exc);
+            } else {
+                throw exc;
+            }
+        }
+
+        /*
+        let debug: boolean = false;
+        if (debug === true) {
+            console.log("Symbol Code: " + symbolCode);
+            console.log("Scale: " + scale);
+            console.log("BBOX: " + bbox);
+            if (controlPoints != null) {
+                console.log("Geo Points: " + controlPoints);
+            }
+            if (tgl != null && tgl.get_Pixels() != null)//pixels != null
+            {
+                console.log("Pixel: " + tgl.get_Pixels().toString());
+            }
+            if (bbox != null) {
+                console.log("geo bounds: " + bbox);
+            }
+            if (rect != null) {
+                console.log("pixel bounds: " + rect.toString());
+            }
+            if (jsonOutput != null) {
+                console.log(jsonOutput.toString());
+            }
+        }
+            */
+
+        ErrorLogger.LogMessage("MultiPointHandler", "RenderSymbol()", "exit RenderSymbol", LogLevel.FINER);
+        return jsonOutput.toString();
+
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.KMLize()}
+     */
+    private static KMLize(id: string, name: string,
+        description: string,
+        symbolCode: string,
+        shapes: Array<ShapeInfo>,
+        modifiers: Array<ShapeInfo>,
+        ipc: IPointConversion,
+        normalize: boolean, textColor: Color): string {
+
+        let kml: string = "";
+
+        let tempModifier: ShapeInfo;
+
+        let cdataStart: string = "<![CDATA[";
+        let cdataEnd: string = "]]>";
+
+        let len: int = shapes.length;
+        kml += ("<Folder id=\"" + id + "\">");
+        kml += ("<name>" + cdataStart + name + cdataEnd + "</name>");
+        kml += ("<visibility>1</visibility>");
+        for (let i: int = 0; i < len; i++) {
+
+            let shapesToAdd: string = MultiPointHandler.ShapeToKMLString(name, description, symbolCode, shapes[i], ipc, normalize);
+            kml += (shapesToAdd);
+        }
+
+        let len2: int = modifiers.length;
+
+        for (let j: int = 0; j < len2; j++) {
+
+            tempModifier = modifiers[j];
+
+            //if(geMap)//if using google earth
+            //assume kml text is going to be centered
+            //AdjustModifierPointToCenter(tempModifier);
+
+            let labelsToAdd: string = MultiPointHandler.LabelToKMLString(tempModifier, ipc, normalize, textColor);
+            kml += (labelsToAdd);
+        }
+
+        kml += ("</Folder>");
+        return kml.toString();
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.ShapeToKMLString()}
+     */
+    private static ShapeToKMLString(name: string,
+        description: string,
+        symbolCode: string,
+        shapeInfo: ShapeInfo,
+        ipc: IPointConversion,
+        normalize: boolean): string {
+
+        let kml: string = "";
+
+        let lineColor: Color;
+        let fillColor: Color;
+        let googleLineColor: string;
+        let googleFillColor: string;
+
+        //String lineStyleId = "lineColor";
+
+        let stroke: BasicStroke;
+        let lineWidth: int = 4;
+
+        symbolCode = JavaRendererUtilities.normalizeSymbolCode(symbolCode);
+
+        let cdataStart: string = "<![CDATA[";
+        let cdataEnd: string = "]]>";
+
+        kml += ("<Placemark>");//("<Placemark id=\"" + id + "_mg" + "\">");
+        kml += ("<description>" + cdataStart + "<b>" + name + "</b><br/>" + "\n" + description + cdataEnd + "</description>");
+        //kml += ("<Style id=\"" + lineStyleId + "\">");
+        kml += ("<Style>");
+
+        lineColor = shapeInfo.getLineColor();
+        if (lineColor != null) {
+            googleLineColor = RendererUtilities.colorToHexString(shapeInfo.getLineColor(), false).substring(1);
+
+            stroke = shapeInfo.getStroke();
+
+            if (stroke != null) {
+                lineWidth = stroke.getLineWidth() as int;
+            }
+
+            googleLineColor = JavaRendererUtilities.ARGBtoABGR(googleLineColor);
+
+            kml += ("<LineStyle>");
+            kml += ("<color>" + googleLineColor + "</color>");
+            kml += ("<colorMode>normal</colorMode>");
+            kml += ("<width>" + lineWidth.toString() + "</width>");
+            kml += ("</LineStyle>");
+        }
+
+        fillColor = shapeInfo.getFillColor();
+        let fillPattern: string = shapeInfo.getPatternFillImage();
+        if (fillColor != null || fillPattern != null) {
+            kml += ("<PolyStyle>");
+
+            if (fillColor != null) {
+                googleFillColor = RendererUtilities.colorToHexString(shapeInfo.getFillColor(), false).substring(1);
+                googleFillColor = JavaRendererUtilities.ARGBtoABGR(googleFillColor);
+                kml += ("<color>" + googleFillColor + "</color>");
+                kml += ("<colorMode>normal</colorMode>");
+            }
+            if (fillPattern != null) {
+                kml += ("<shader>" + fillPattern + "</shader>");
+            }
+
+            kml += ("<fill>1</fill>");
+            if (lineColor != null) {
+                kml += ("<outline>1</outline>");
+            } else {
+                kml += ("<outline>0</outline>");
+            }
+            kml += ("</PolyStyle>");
+        }
+
+        kml += ("</Style>");
+
+        let shapesArray: Point2D[][] = shapeInfo.getPolylines();
+        let len: int = shapesArray.length;
+        kml += ("<MultiGeometry>");
+
+        for (let i: int = 0; i < len; i++) {
+            let shape: Point2D[] = shapesArray[i];
+            normalize = MultiPointHandler.normalizePoints(shape, ipc);
+            if (lineColor != null && fillColor == null) {
+                kml += ("<LineString>");
+                kml += ("<tessellate>1</tessellate>");
+                kml += ("<altitudeMode>clampToGround</altitudeMode>");
+                kml += ("<coordinates>");
+                let n: int = shape.length;
+                //for (int j = 0; j < shape.length; j++) 
+                for (let j: int = 0; j < n; j++) {
+                    let coord: Point2D = shape[j] as Point2D;
+                    let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+                    if (normalize) {
+                        geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
+                    }
+
+                    let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
+                    let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+
+                    kml += (longitude);
+                    kml += (",");
+                    kml += (latitude);
+                    if (j < shape.length - 1) {
+
+                        kml += (" ");
+                    }
+
+                }
+
+                kml += ("</coordinates>");
+                kml += ("</LineString>");
+            }
+
+            if (fillColor != null) {
+
+                if (i === 0) {
+                    kml += ("<Polygon>");
+                }
+                //kml += ("<outerBoundaryIs>");
+                if (i === 1 && len > 1) {
+                    kml += ("<innerBoundaryIs>");
+                } else {
+                    kml += ("<outerBoundaryIs>");
+                }
+                kml += ("<LinearRing>");
+                kml += ("<altitudeMode>clampToGround</altitudeMode>");
+                kml += ("<tessellate>1</tessellate>");
+                kml += ("<coordinates>");
+
+                //this section is a workaround for a google earth bug. Issue 417 was closed
+                //for linestrings but they did not fix the smae issue for fills. If Google fixes the issue
+                //for fills then this section will need to be commented or it will induce an error.
+                let lastLongitude: double = Number.MIN_VALUE;
+                if (normalize === false && MultiPointHandler.IsOnePointSymbolCode(symbolCode)) {
+                    let n: int = shape.length;
+                    //for (int j = 0; j < shape.length; j++) 
+                    for (let j: int = 0; j < n; j++) {
+                        let coord: Point2D = shape[j] as Point2D;
+                        let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+                        let longitude: double = geoCoord.getX();
+                        if (lastLongitude !== Number.MIN_VALUE) {
+                            if (Math.abs(longitude - lastLongitude) > 180) {
+                                normalize = true;
+                                break;
+                            }
+                        }
+                        lastLongitude = longitude;
+                    }
+                }
+                let n: int = shape.length;
+                //for (int j = 0; j < shape.length; j++) 
+                for (let j: int = 0; j < n; j++) {
+                    let coord: Point2D = shape[j] as Point2D;
+                    let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+
+                    let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
+                    let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+
+                    //fix for fill crossing DTL
+                    if (normalize) {
+                        if (longitude > 0) {
+                            longitude -= 360;
+                        }
+                    }
+
+                    kml += (longitude);
+                    kml += (",");
+                    kml += (latitude);
+                    if (j < shape.length - 1) {
+
+                        kml += (" ");
+                    }
+
+                }
+
+                kml += ("</coordinates>");
+                kml += ("</LinearRing>");
+                if (i === 1 && len > 1) {
+                    kml += ("</innerBoundaryIs>");
+                } else {
+                    kml += ("</outerBoundaryIs>");
+                }
+                if (i === len - 1) {
+                    kml += ("</Polygon>");
+                }
+            }
+        }
+
+        kml += ("</MultiGeometry>");
+        kml += ("</Placemark>");
+
+        return kml.toString();
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.LabelToKMLString()}
+     */
+    private static LabelToKMLString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean, textColor: Color): string {
+        let kml: string = "";
+
+        //Point2D coord = (Point2D) new Point2D(shapeInfo.getGlyphPosition().getX(), shapeInfo.getGlyphPosition().getY());
+        let coord: Point2D = new Point2D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY()) as Point2D;
+        let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+        //M. Deutch 9-26-11
+        if (normalize) {
+            geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
+        }
+        let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
+        let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+        let angle: number = Math.round(shapeInfo.getModifierAngle());
+
+        let text: string = shapeInfo.getModifierString();
+
+        let cdataStart: string = "<![CDATA[";
+        let cdataEnd: string = "]]>";
+
+        let color: string = RendererUtilities.colorToHexString(textColor, false).substring(1);
+        color = JavaRendererUtilities.ARGBtoABGR(color);
+        let kmlScale: double = RendererSettings.getInstance().getKMLLabelScale();
+
+        if (kmlScale > 0 && text != null && text !== "") {
+            kml += ("<Placemark>");//("<Placemark id=\"" + id + "_lp" + i + "\">");
+            kml += ("<name>" + cdataStart + text + cdataEnd + "</name>");
+            kml += ("<Style>");
+            kml += ("<IconStyle>");
+            kml += ("<scale>" + kmlScale + "</scale>");
+            kml += ("<heading>" + angle + "</heading>");
+            kml += ("<Icon>");
+            kml += ("<href></href>");
+            kml += ("</Icon>");
+            kml += ("</IconStyle>");
+            kml += ("<LabelStyle>");
+            kml += ("<color>" + color + "</color>");
+            kml += ("<scale>" + kmlScale.toString() + "</scale>");
+            kml += ("</LabelStyle>");
+            kml += ("</Style>");
+            kml += ("<Point>");
+            kml += ("<extrude>1</extrude>");
+            kml += ("<altitudeMode>relativeToGround</altitudeMode>");
+            kml += ("<coordinates>");
+            kml += (longitude);
+            kml += (",");
+            kml += (latitude);
+            kml += ("</coordinates>");
+            kml += ("</Point>");
+            kml += ("</Placemark>");
+        } else {
+            return "";
+        }
+
+        return kml.toString();
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.GeoJSONize()}
+     */
+    private static GeoJSONize(shapes: Array<ShapeInfo>, modifiers: Array<ShapeInfo>, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
+
+        let jstr: string = "";
+        let tempModifier: ShapeInfo;
+        let fc: string = "";//JSON feature collection
+
+        fc += ("[");
+
+        let len: int = shapes.length;
+        for (let i: int = 0; i < len; i++) 
+        {
+
+            let shapesToAdd: string = null;
+            let tempShape:ShapeInfo = shapes[i];
+            if(tempShape != null && tempShape !== undefined) {
+                shapesToAdd = MultiPointHandler.ShapeToGeoJSONString(tempShape, ipc, normalize);
+                if (shapesToAdd != null && shapesToAdd.length > 0) {
+                    fc += (shapesToAdd);
+                    if (i < len - 1) {
+                        fc += (",");
+                    }
+                }
+            }
+        }
+
+        let len2: int = modifiers.length;
+
+        for (let j: int = 0; j < len2; j++) {
+            tempModifier = modifiers[j];
+
+            let modifiersToAdd: string;
+            if (modifiers[j].getModifierImage() != null) {
+                modifiersToAdd = MultiPointHandler.ImageToGeoJSONString(tempModifier, ipc, normalize);
+            } else {
+                modifiersToAdd = MultiPointHandler.LabelToGeoJSONString(tempModifier, ipc, normalize, textColor, textBackgroundColor);
+            }
+            if (modifiersToAdd.length > 0) {
+                if (fc.length > 1)
+                    fc += (",");
+                fc += (modifiersToAdd);
+            }
+        }
+        fc += ("]");
+        let GeoJSON: string = fc.toString();
+        return GeoJSON;
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.ShapeToGeoJSONString()}
+     */
+    private static ShapeToGeoJSONString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean): string {
+        let JSONed: string = "";
+        let properties: string = "";
+        let geometry: string = "";
+        let geometryType: string;
+        let sda: string;
+        /*
+         NOTE: Google Earth / KML colors are backwards.
+         They are ordered Alpha,Blue,Green,Red, not Red,Green,Blue,Aplha like the rest of the world
+         * */
+        let lineColor: Color = shapeInfo.getLineColor();
+        let fillColor: Color = shapeInfo.getFillColor();
+
+        if (shapeInfo.getShapeType() === ShapeInfo.SHAPE_TYPE_FILL || fillColor != null || shapeInfo.getPatternFillImage() != null) {
+            geometryType = "\"Polygon\"";
+        } else //if(shapeInfo.getShapeType() == ShapeInfo.SHAPE_TYPE_POLYLINE)
+        {
+            geometryType = "\"MultiLineString\"";
+        }
+
+        let stroke: BasicStroke;
+        stroke = shapeInfo.getStroke();
+        let lineWidth: int = 4;
+
+        if (stroke != null) {
+            lineWidth = Math.trunc(stroke.getLineWidth());
+            //lineWidth++;
+            //console.log("lineWidth: " + lineWidth.toString());
+        }
+
+        //generate JSON properties for feature
+        properties += ("\"properties\":{");
+        properties += ("\"label\":\"\",");
+        if (lineColor != null) {
+            properties += ("\"strokeColor\":\"" + RendererUtilities.colorToHexString(lineColor, false) + "\",");
+            properties += ("\"lineOpacity\":" + (lineColor.getAlpha() / 255).toString() + ",");
+        }
+        if (fillColor != null) {
+            properties += ("\"fillColor\":\"" + RendererUtilities.colorToHexString(fillColor, false) + "\",");
+            properties += ("\"fillOpacity\":" + (fillColor.getAlpha() / 255).toString() + ",");
+        }
+        if (shapeInfo.getPatternFillImage() != null) {
+            properties += ("\"fillPattern\":\"" + shapeInfo.getPatternFillImage() + "\",");
+        }
+        if (stroke.getDashArray() != null) {
+            sda = "\"strokeDasharray\":[" + stroke.getDashArray().toString() + "],";
+            properties += (sda);
+        }
+
+
+        let lineCap: int = stroke.getEndCap();
+        properties += ("\"lineCap\":" + lineCap + ",");
+
+        let strokeWidth: string = lineWidth.toString();
+        properties += ("\"strokeWidth\":" + strokeWidth + ",");
+        properties += ("\"strokeWeight\":" + strokeWidth + "");
+        properties += ("},");
+
+
+        properties += ("\"style\":{");
+        if (lineColor != null) {
+            properties += ("\"stroke\":\"" + RendererUtilities.colorToHexString(lineColor, false) + "\",");
+            properties += ("\"line-opacity\":" + (lineColor.getAlpha() / 255).toString() + ",");
+        }
+        if (fillColor != null) {
+            properties += ("\"fill\":\"" + RendererUtilities.colorToHexString(fillColor, false) + "\",");
+            properties += ("\"fill-opacity\":" + (fillColor.getAlpha() / 255).toString() + ",");
+        }
+        if (stroke.getDashArray() != null) {
+            let da: number[] = stroke.getDashArray();
+            sda = da[0].toString();
+            if (da.length > 1) {
+                for (let i: int = 1; i < da.length; i++) {
+                    sda = sda + " " + da[i].toString();
+                }
+            }
+            sda = "\"stroke-dasharray\":\"" + sda + "\",";
+            properties += (sda);
+            sda = null;
+        }
+
+        if (lineCap === BasicStroke.CAP_SQUARE) {
+
+            properties += ("\"stroke-linecap\":\"square\",");
+        }
+
+        else {
+            if (lineCap === BasicStroke.CAP_ROUND) {
+
+                properties += ("\"stroke-linecap\":\"round\",");
+            }
+
+            else {
+                if (lineCap === BasicStroke.CAP_BUTT) {
+
+                    properties += ("\"stroke-linecap\":\"butt\",");
+                }
+
+            }
+
+        }
+
+
+        strokeWidth = lineWidth.toString();
+        properties += ("\"stroke-width\":" + strokeWidth);
+        properties += ("}");
+
+
+        //generate JSON geometry for feature
+        geometry += ("\"geometry\":{\"type\":");
+        geometry += (geometryType);
+        geometry += (",\"coordinates\":[");
+
+        let shapesArray: Point2D[][] = shapeInfo.getPolylines();
+
+        for (let i: int = 0; i < shapesArray.length; i++) {
+            let pointList: Point2D[] = shapesArray[i];
+
+            normalize = MultiPointHandler.normalizePoints(pointList, ipc);
+
+            geometry += ("[");
+
+            //console.log("Pixel Coords:");
+            for (let j: int = 0; j < pointList.length; j++) {
+                let coord: Point2D = pointList[j] as Point2D;
+                let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+                //M. Deutch 9-27-11
+                if (normalize) {
+                    geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
+                }
+                let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
+                let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+
+                //fix for fill crossing DTL
+                if (normalize && fillColor != null) {
+                    if (longitude > 0) {
+                        longitude -= 360;
+                    }
+                }
+
+                //diagnostic M. Deutch 10-18-11
+                //set the point as geo so that the 
+                //coord.setLocation(longitude, latitude);
+                coord = new Point2D(longitude, latitude);
+                pointList[j] = coord;
+                //end section
+
+                geometry += ("[");
+                geometry += (longitude);
+                geometry += (",");
+                geometry += (latitude);
+                geometry += ("]");
+
+                if (j < (pointList.length - 1)) {
+                    geometry += (",");
+                }
+            }
+
+            geometry += ("]");
+
+            if (i < (shapesArray.length - 1)) {
+                geometry += (",");
+            }
+        }
+        geometry += ("]}");
+
+        JSONed += ("{\"type\":\"Feature\",");
+        JSONed += (properties.toString());
+        JSONed += (",");
+        JSONed += (geometry.toString());
+        JSONed += ("}");
+
+        return JSONed.toString();
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.ImageToGeoJSONString()}
+     */
+    private static ImageToGeoJSONString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean): string {
+
+        let JSONed: string = "";
+        let properties: string = "";
+        let geometry: string = "";
+
+        //AffineTransform at = shapeInfo.getAffineTransform();
+        //Point2D coord = (Point2D)new Point2D(at.getTranslateX(), at.getTranslateY());
+        //Point2D coord = (Point2D) new Point2D(shapeInfo.getGlyphPosition().getX(), shapeInfo.getGlyphPosition().getY());
+        let coord: Point2D = new Point2D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY()) as Point2D;
+        let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+        //M. Deutch 9-27-11
+        if (normalize) {
+            geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
+        }
+        let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
+        let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+        let angle: double = shapeInfo.getModifierAngle();
+        coord.setLocation(longitude, latitude);
+
+        //diagnostic M. Deutch 10-18-11
+        shapeInfo.setGlyphPosition(coord);
+
+        let image: string = shapeInfo.getModifierImage();
+
+        let RS: RendererSettings = RendererSettings.getInstance();
+
+        if (image != null) {
+
+            JSONed += ("{\"type\":\"Feature\",\"properties\":{\"image\":\"");
+            JSONed += (image);
+            JSONed += ("\",\"rotation\":");
+            JSONed += (angle);
+            JSONed += (",\"angle\":");
+            JSONed += (angle);
+            JSONed += ("},");
+            JSONed += ("\"geometry\":{\"type\":\"Point\",\"coordinates\":[");
+            JSONed += (longitude);
+            JSONed += (",");
+            JSONed += (latitude);
+            JSONed += ("]");
+            JSONed += ("}}");
+
+        } else {
+            return "";
+        }
+
+        return JSONed.toString();
+    }
+
+    /**
+     * 3D Version of {@link MultiPointHandler.LabelToGeoJSONString()}
+     */
+    private static LabelToGeoJSONString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
+
+        let JSONed: string = "";
+        let properties: string = "";
+        let geometry: string = "";
+
+        let outlineColor: Color = MultiPointHandler.getIdealTextBackgroundColor(textColor);
+        if (textBackgroundColor != null) {
+            outlineColor = textBackgroundColor;
+        }
+
+        //AffineTransform at = shapeInfo.getAffineTransform();
+        //Point2D coord = (Point2D)new Point2D(at.getTranslateX(), at.getTranslateY());
+        //Point2D coord = (Point2D) new Point2D(shapeInfo.getGlyphPosition().getX(), shapeInfo.getGlyphPosition().getY());
+        let coord: Point2D = new Point2D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY()) as Point2D;
+        let geoCoord: Point2D = ipc.PixelsToGeo(coord);
+        //M. Deutch 9-27-11
+        if (normalize) {
+            geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
+        }
+        let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
+        let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+        let angle: double = shapeInfo.getModifierAngle();
+        coord.setLocation(longitude, latitude);
+
+        //diagnostic M. Deutch 10-18-11
+        shapeInfo.setGlyphPosition(coord);
+
+        let text: string = shapeInfo.getModifierString();
+
+        let justify: int = shapeInfo.getTextJustify();
+        let strJustify: string = "left";
+        if (justify === 0) {
+            strJustify = "left";
+        } else {
+            if (justify === 1) {
+                strJustify = "center";
+            } else {
+                if (justify === 2) {
+                    strJustify = "right";
+                }
+            }
+
+        }
+
+
+        let RS: RendererSettings = RendererSettings.getInstance();
+
+        if (text != null && text !== "") {
+
+            JSONed += ("{\"type\":\"Feature\",\"properties\":{\"label\":\"");
+            JSONed += (text);
+            JSONed += ("\",\"pointRadius\":0,\"fontColor\":\"");
+            JSONed += (RendererUtilities.colorToHexString(textColor, false));
+            JSONed += ("\",\"fontSize\":\"");
+            JSONed += (RS.getMPLabelFont().getSize().toString() + "pt\"");
+            JSONed += (",\"fontFamily\":\"");
+            JSONed += (RS.getMPLabelFont().getName());
+            JSONed += (", sans-serif");
+
+            if (RS.getMPLabelFont().getType() === Font.BOLD) {
+                JSONed += ("\",\"fontWeight\":\"bold\"");
+            } else {
+                JSONed += ("\",\"fontWeight\":\"normal\"");
+            }
+
+            //JSONed += (",\"labelAlign\":\"lm\"");
+            JSONed += (",\"labelAlign\":\"");
+            JSONed += (strJustify);
+            JSONed += ("\",\"labelBaseline\":\"alphabetic");
+            JSONed += ("\",\"labelXOffset\":0");
+            JSONed += (",\"labelYOffset\":0");
+            JSONed += (",\"labelOutlineColor\":\"");
+            JSONed += (RendererUtilities.colorToHexString(outlineColor, false));
+            JSONed += ("\",\"labelOutlineWidth\":");
+            JSONed += ("4");
+            JSONed += (",\"rotation\":");
+            JSONed += (angle);
+            JSONed += (",\"angle\":");
+            JSONed += (angle);
+            JSONed += ("},");
+
+            JSONed += ("\"geometry\":{\"type\":\"Point\",\"coordinates\":[");
+            JSONed += (longitude);
+            JSONed += (",");
+            JSONed += (latitude);
+            JSONed += ("]");
+            JSONed += ("}}");
+
+        } else {
+            return "";
+        }
+
+        return JSONed.toString();
+    }
+}

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -365,7 +365,7 @@ export class Shape3DHandler {
                 shapes.push(topShape);
             }
 
-            const modifierAlt = Math.max(...altitudes.splice(0, mSymbol.getSymbolShapes().length * 2));
+            const modifierAlt = Math.max(...altitudes.slice(0, mSymbol.getSymbolShapes().length * 2));
             for (const oldShape of mSymbol.getModifierShapes()) {
                 var modShape = new ShapeInfo3D();
                 modShape.setModifierString(oldShape.getModifierString());
@@ -697,7 +697,7 @@ export class Shape3DHandler {
                 shapes.push(topShape);
             }
 
-            const modifierAlt = Math.max(...altitudes.splice(0, mSymbol.getSymbolShapes().length * 2));
+            const modifierAlt = Math.max(...altitudes.slice(0, mSymbol.getSymbolShapes().length * 2));
             for (const oldShape of mSymbol.getModifierShapes()) {
                 var modShape = new ShapeInfo3D();
                 modShape.setModifierString(oldShape.getModifierString());
@@ -1263,8 +1263,6 @@ export class Shape3DHandler {
      */
     private static ImageToGeoJSONString(shapeInfo: ShapeInfo3D, ipc: IPointConversion, normalize: boolean): string {
         let JSONed: string = "";
-        let properties: string = "";
-        let geometry: string = "";
 
         //AffineTransform at = shapeInfo.getAffineTransform();
         //Point2D coord = (Point2D)new Point2D(at.getTranslateX(), at.getTranslateY());
@@ -1317,10 +1315,7 @@ export class Shape3DHandler {
      * 3D Version of {@link MultiPointHandler.LabelToGeoJSONString()}
      */
     private static LabelToGeoJSONString(shapeInfo: ShapeInfo3D, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
-
         let JSONed: string = "";
-        let properties: string = "";
-        let geometry: string = "";
 
         let outlineColor: Color = MultiPointHandler.getIdealTextBackgroundColor(textColor);
         if (textBackgroundColor != null) {

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -14,11 +14,15 @@ import { MilStdAttributes } from "../../renderer/utilities/MilStdAttributes";
 import { MilStdSymbol } from "../../renderer/utilities/MilStdSymbol";
 import { RendererSettings } from "../../renderer/utilities/RendererSettings";
 import { RendererUtilities } from "../../renderer/utilities/RendererUtilities";
+import { ShapeInfo3D } from "./utilities/ShapeInfo3D";
 import { PointConverter } from "./PointConverter";
 import { JavaRendererUtilities } from "./utilities/JavaRendererUtilities";
 import { WebRenderer } from "./WebRenderer";
+import { Point3D } from "./utilities/Point3D";
 import { type int, type double } from "../../graphics2d/BasicTypes";
 import { BasicStroke } from "../../graphics2d/BasicStroke";
+import { Modifiers } from "../../renderer/utilities/Modifiers";
+import { SymbolUtilities } from "../../renderer/utilities/SymbolUtilities";
 import { ShapeInfo } from "../../renderer/utilities/ShapeInfo";
 import { Font } from "../../graphics2d/Font";
 
@@ -50,21 +54,49 @@ export class Shape3DHandler {
         let rect: Rectangle;
         let coordinates: string[] = controlPoints.split(" ");
         let tgl: TGLight = new TGLight();
-        let shapes: Array<ShapeInfo> = new Array<ShapeInfo>();
-        let modifiers: Array<ShapeInfo> = new Array<ShapeInfo>();
+        let shapes: Array<ShapeInfo3D> = new Array<ShapeInfo3D>();
+        let modifiers: Array<ShapeInfo3D> = new Array<ShapeInfo3D>();
         //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
         let geoCoords: Array<Point2D> = new Array<Point2D>();
         let len: int = coordinates.length;
         //diagnostic create geoCoords here
         let coordsUL: Point2D = null;
 
+        // 3D default colors
+        if (symbolAttributes.get(MilStdAttributes.LineColor) == null) {
+            var defaultColor = SymbolUtilities.getLineColorOfAffiliation(symbolCode);
+            if (defaultColor == null) {
+                defaultColor = new Color(Color.BLACK);
+            }
+            symbolAttributes.set(MilStdAttributes.LineColor, defaultColor.toHexString());
+        }
+        if (symbolAttributes.get(MilStdAttributes.FillColor) == null) {
+            var defaultColor = SymbolUtilities.getFillColorOfAffiliation(symbolCode);
+            if (defaultColor == null) {
+                defaultColor = new Color(Color.BLACK);
+            }
+            defaultColor.setAlpha(170);
+            symbolAttributes.set(MilStdAttributes.FillColor, defaultColor.toHexString(true));
+        }
+
+        if (!JavaRendererUtilities.is3dSymbol(symbolCode)) {
+            const basicID: string = SymbolUtilities.getBasicSymbolID(symbolCode);
+            const errorMsg = "Basic ID: " + basicID + " is not a 3D Symbol";
+            let ErrorOutput: string = "";
+            ErrorOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the 3D MilStdSymbol " + symbolCode + " - ID: " + id + " - ");
+            ErrorOutput += errorMsg; //reason for error
+            ErrorOutput += ("\"}");
+            ErrorLogger.LogMessage("Shape3DHandler", "RenderMilStd3dSymbol", errorMsg, LogLevel.FINE);
+            return ErrorOutput;
+        }
+
         let symbolIsValid: string = MultiPointHandler.canRenderMultiPoint(symbolCode, symbolModifiers, len);
         if (symbolIsValid !== "true") {
             let ErrorOutput: string = "";
-            ErrorOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + " - ID: " + id + " - ");
+            ErrorOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the 3D MilStdSymbol " + symbolCode + " - ID: " + id + " - ");
             ErrorOutput += symbolIsValid; //reason for error
             ErrorOutput += ("\"}");
-            ErrorLogger.LogMessage("MultiPointHandler", "RenderSymbol", symbolIsValid, LogLevel.FINE);
+            ErrorLogger.LogMessage("Shape3DHandler", "RenderMilStd3dSymbol", symbolIsValid, LogLevel.FINE);
             return ErrorOutput;
         }
 
@@ -246,11 +278,11 @@ export class Shape3DHandler {
 
             //String fillColor = null;
             let mSymbol: MilStdSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
-            
+
             if (format == WebRenderer.OUTPUT_FORMAT_GEOSVG) {
                 // Use dash array and hatch pattern fill for SVG output
-                symbolAttributes.set(MilStdAttributes.UseDashArray, 'true')
-                symbolAttributes.set(MilStdAttributes.UsePatternFill, "true")
+                symbolAttributes.set(MilStdAttributes.UseDashArray, 'true');
+                symbolAttributes.set(MilStdAttributes.UsePatternFill, "true");
             }
 
             if (symbolModifiers != null || symbolAttributes != null) {
@@ -265,46 +297,96 @@ export class Shape3DHandler {
                 clsRenderer.renderWithPolylines(mSymbol, ipc, bboxCoords);
             }
 
-            shapes = mSymbol.getSymbolShapes();
-            modifiers = mSymbol.getModifierShapes();
+            // Convert 2D shape to 3D
+            if (MSLookup.getInstance().getMSLInfo(symbolCode).getDrawRule() === DrawRules.CORRIDOR1) {
+                // Remove circles from air corridor for 3d
+                // Set line color for other shapes
+                for (let i = 0; i < mSymbol.getSymbolShapes().length - 1; i++) {
+                    mSymbol.getSymbolShapes()[i].setLineColor(mSymbol.getSymbolShapes()[mSymbol.getSymbolShapes().length - 1].getLineColor());
+                }
+                mSymbol.setSymbolShapes(mSymbol.getSymbolShapes().slice(0, -1).reverse());
+            }
+            // Confirm there are at least two altitudes per shape
+            let altitudes = mSymbol.getModifiers_AM_AN_X(Modifiers.X_ALTITUDE_DEPTH);
+            if (altitudes.length === 1) {
+                altitudes = [0, altitudes[0]];
+            }
+            const lastAlt = altitudes[altitudes.length - 1];
+            const nextToLastAlt = altitudes[altitudes.length - 2];
+            while (altitudes.length < mSymbol.getSymbolShapes().length * 2) {
+                altitudes.push(nextToLastAlt, lastAlt);
+            }
+            for (let shapeIndex = 0; shapeIndex < mSymbol.getSymbolShapes().length; shapeIndex++) {
+                const minAlt = altitudes[shapeIndex * 2];
+                const maxAlt = altitudes[(shapeIndex * 2) + 1];
+                const oldShape = mSymbol.getSymbolShapes()[shapeIndex];
 
-            if (format === WebRenderer.OUTPUT_FORMAT_JSON) {
-                jsonOutput += ("{\"type\":\"symbol\",");
-                jsonContent = MultiPointHandler.JSONize(shapes, modifiers, ipc, true, normalize);
-                jsonOutput += (jsonContent);
-                jsonOutput += ("}");
-            } else if (format === WebRenderer.OUTPUT_FORMAT_KML) {
+                var bottomShape = new ShapeInfo3D();
+                bottomShape.setShapeType(oldShape.getShapeType());
+                bottomShape.setStroke(oldShape.getStroke());
+                bottomShape.setLineColor(oldShape.getLineColor());
+                bottomShape.setFillColor(oldShape.getFillColor());
+                bottomShape.setPatternFillImage(oldShape.getPatternFillImageInfo());
+                bottomShape.setPolylines([]);
+                var topShape = new ShapeInfo3D();
+                topShape.setShapeType(oldShape.getShapeType());
+                topShape.setStroke(oldShape.getStroke());
+                topShape.setLineColor(oldShape.getLineColor());
+                topShape.setFillColor(oldShape.getFillColor());
+                topShape.setPatternFillImage(oldShape.getPatternFillImageInfo());
+                topShape.setPolylines([]);
+
+                for (let polyLineIndex = 0; polyLineIndex < oldShape.getPolylines().length; polyLineIndex++) {
+                    const polyline = oldShape.getPolylines()[polyLineIndex];
+                    bottomShape.getPolylines().push([]);
+                    topShape.getPolylines().push([]);
+                    for (let ptIndex = 0; ptIndex < polyline.length; ptIndex++) {
+                        const pt = polyline[ptIndex];
+                        const pt2 = polyline[(ptIndex + 1) % polyline.length];
+                        bottomShape.getPolylines()[polyLineIndex].push(new Point3D(pt, minAlt));
+                        topShape.getPolylines()[polyLineIndex].push(new Point3D(pt, maxAlt));
+
+                        var sideShape = new ShapeInfo3D();
+                        sideShape.setShapeType(oldShape.getShapeType());
+                        sideShape.setStroke(oldShape.getStroke());
+                        sideShape.setLineColor(oldShape.getLineColor());
+                        sideShape.setFillColor(oldShape.getFillColor());
+                        sideShape.setPatternFillImage(oldShape.getPatternFillImageInfo());
+                        sideShape.setPolylines([[new Point3D(pt, minAlt), new Point3D(pt2, minAlt), new Point3D(pt2, maxAlt), new Point3D(pt, maxAlt), new Point3D(pt, minAlt)]]);
+                        shapes.push(sideShape);
+                    }
+                }
+                shapes.push(bottomShape);
+                shapes.push(topShape);
+            }
+
+            const modifierAlt = Math.max(...altitudes.splice(0, mSymbol.getSymbolShapes().length * 2));
+            for (const oldShape of mSymbol.getModifierShapes()) {
+                var modShape = new ShapeInfo3D();
+                modShape.setModifierString(oldShape.getModifierString());
+                modShape.setModifierPosition(new Point3D(oldShape.getModifierPosition(), modifierAlt));
+                modShape.setModifierAngle(oldShape.getModifierAngle());
+                modShape.setTextJustify(oldShape.getTextJustify());
+                modShape.setModifierImage(oldShape.getModifierImageInfo());
+
+                modifiers.push(modShape);
+            }
+
+            if (format === WebRenderer.OUTPUT_FORMAT_KML) {
                 var textColor = mSymbol.getTextColor();
-                if(textColor==null)
-                    textColor=mSymbol.getLineColor();
+                if (textColor == null)
+                    textColor = mSymbol.getLineColor();
 
-                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
-                jsonOutput += jsonContent;
+                jsonOutput = Shape3DHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, altitudeMode);
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
-                /*
                 jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
-                jsonContent = GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
-                jsonOutput += (jsonContent);
-                jsonOutput += (",\"properties\":{\"id\":\"");
-                jsonOutput += (id);
-                jsonOutput += ("\",\"name\":\"");
-                jsonOutput += (name);
-                jsonOutput += ("\",\"description\":\"");
-                jsonOutput += (description);
-                jsonOutput += ("\",\"symbolID\":\"");
-                jsonOutput += (symbolCode);
-                jsonOutput += ("\",\"wasClipped\":\"");
-                jsonOutput += (mSymbol.get_WasClipped()).toString();
-                jsonOutput += ("\"}}");         */
-
-                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
-                jsonContent = MultiPointHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonContent = Shape3DHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
                 jsonOutput += (jsonContent);
 
                 //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
                 jsonOutput = jsonOutput.slice(0, -1);
                 if (jsonContent.length > 2)
-                    jsonOutput += ","
+                    jsonOutput += ",";
                 jsonOutput += ("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
 
                 jsonOutput += (",\"properties\":{\"id\":\"");
@@ -317,74 +399,44 @@ export class Shape3DHandler {
                 jsonOutput += (symbolCode);
                 jsonOutput += ("\",\"wasClipped\":\"");
                 jsonOutput += (mSymbol.get_WasClipped()).toString();
-                //jsonOutput += ("\"}}");
-
                 jsonOutput += ("\"}}]}");
-            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOSVG) {
-                let textColor = mSymbol.getTextColor() ? mSymbol.getTextColor().toHexString(false) : "";
-                let backgroundColor = mSymbol.getTextBackgroundColor() ? mSymbol.getTextBackgroundColor().toHexString(false) : "";
-                //returns an svg with a geoTL and geoBR value to use to place the canvas on the map
-                jsonOutput = MultiPointHandlerSVG.GeoSVGize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, backgroundColor, mSymbol.get_WasClipped());
             }
         } catch (exc) {
             if (exc instanceof Error) {
                 let st: string = JavaRendererUtilities.getStackTrace(exc);
                 jsonOutput = "";
-                jsonOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + ": " + "- ");
+                jsonOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the 3D MilStdSymbol " + symbolCode + ": " + "- ");
                 jsonOutput += (exc.message + " - ");
                 jsonOutput += (st);
                 jsonOutput += ("\"}");
 
-                ErrorLogger.LogException("MultiPointHandler", "RenderSymbol", exc);
+                ErrorLogger.LogException("Shape3DHandler", "RenderMilStd3dSymbol", exc);
             } else {
                 throw exc;
             }
         }
 
-        /*
-        let debug: boolean = false;
-        if (debug === true) {
-            console.log("Symbol Code: " + symbolCode);
-            console.log("Scale: " + scale);
-            console.log("BBOX: " + bbox);
-            if (controlPoints != null) {
-                console.log("Geo Points: " + controlPoints);
-            }
-            if (tgl != null && tgl.get_Pixels() != null)//pixels != null
-            {
-                console.log("Pixel: " + tgl.get_Pixels().toString());
-            }
-            if (bbox != null) {
-                console.log("geo bounds: " + bbox);
-            }
-            if (rect != null) {
-                console.log("pixel bounds: " + rect.toString());
-            }
-            if (jsonOutput != null) {
-                console.log(jsonOutput.toString());
-            }
-        }
-            */
-
-        ErrorLogger.LogMessage("MultiPointHandler", "RenderSymbol()", "exit RenderSymbol", LogLevel.FINER);
+        ErrorLogger.LogMessage("Shape3DHandler", "RenderMilStd3dSymbol()", "exit RenderMilStd3dSymbol", LogLevel.FINER);
         return jsonOutput.toString();
-
     }
 
     /**
      * 3D Version of {@link MultiPointHandler.KMLize()}
      */
-    private static KMLize(id: string, name: string,
+    private static KMLize(id: string,
+        name: string,
         description: string,
         symbolCode: string,
-        shapes: Array<ShapeInfo>,
-        modifiers: Array<ShapeInfo>,
+        shapes: Array<ShapeInfo3D>,
+        modifiers: Array<ShapeInfo3D>,
         ipc: IPointConversion,
-        normalize: boolean, textColor: Color): string {
+        normalize: boolean,
+        textColor: Color,
+        altitudeMode: string): string {
 
         let kml: string = "";
 
-        let tempModifier: ShapeInfo;
+        let tempModifier: ShapeInfo3D;
 
         let cdataStart: string = "<![CDATA[";
         let cdataEnd: string = "]]>";
@@ -394,8 +446,7 @@ export class Shape3DHandler {
         kml += ("<name>" + cdataStart + name + cdataEnd + "</name>");
         kml += ("<visibility>1</visibility>");
         for (let i: int = 0; i < len; i++) {
-
-            let shapesToAdd: string = MultiPointHandler.ShapeToKMLString(name, description, symbolCode, shapes[i], ipc, normalize);
+            let shapesToAdd: string = Shape3DHandler.ShapeToKMLString(name, description, symbolCode, shapes[i], ipc, normalize, altitudeMode);
             kml += (shapesToAdd);
         }
 
@@ -409,7 +460,7 @@ export class Shape3DHandler {
             //assume kml text is going to be centered
             //AdjustModifierPointToCenter(tempModifier);
 
-            let labelsToAdd: string = MultiPointHandler.LabelToKMLString(tempModifier, ipc, normalize, textColor);
+            let labelsToAdd: string = Shape3DHandler.LabelToKMLString(tempModifier, ipc, normalize, textColor, altitudeMode);
             kml += (labelsToAdd);
         }
 
@@ -423,9 +474,10 @@ export class Shape3DHandler {
     private static ShapeToKMLString(name: string,
         description: string,
         symbolCode: string,
-        shapeInfo: ShapeInfo,
+        shapeInfo: ShapeInfo3D,
         ipc: IPointConversion,
-        normalize: boolean): string {
+        normalize: boolean,
+        altitudeMode: string): string {
 
         let kml: string = "";
 
@@ -451,15 +503,13 @@ export class Shape3DHandler {
 
         lineColor = shapeInfo.getLineColor();
         if (lineColor != null) {
-            googleLineColor = RendererUtilities.colorToHexString(shapeInfo.getLineColor(), false).substring(1);
+            googleLineColor = RendererUtilities.colorToHexString(shapeInfo.getLineColor(), true).substring(1);
+            googleLineColor = JavaRendererUtilities.ARGBtoABGR(googleLineColor);
 
             stroke = shapeInfo.getStroke();
-
             if (stroke != null) {
                 lineWidth = stroke.getLineWidth() as int;
             }
-
-            googleLineColor = JavaRendererUtilities.ARGBtoABGR(googleLineColor);
 
             kml += ("<LineStyle>");
             kml += ("<color>" + googleLineColor + "</color>");
@@ -474,7 +524,7 @@ export class Shape3DHandler {
             kml += ("<PolyStyle>");
 
             if (fillColor != null) {
-                googleFillColor = RendererUtilities.colorToHexString(shapeInfo.getFillColor(), false).substring(1);
+                googleFillColor = RendererUtilities.colorToHexString(shapeInfo.getFillColor(), true).substring(1);
                 googleFillColor = JavaRendererUtilities.ARGBtoABGR(googleFillColor);
                 kml += ("<color>" + googleFillColor + "</color>");
                 kml += ("<colorMode>normal</colorMode>");
@@ -494,22 +544,22 @@ export class Shape3DHandler {
 
         kml += ("</Style>");
 
-        let shapesArray: Point2D[][] = shapeInfo.getPolylines();
+        let shapesArray: Point3D[][] = shapeInfo.getPolylines();
         let len: int = shapesArray.length;
         kml += ("<MultiGeometry>");
 
         for (let i: int = 0; i < len; i++) {
-            let shape: Point2D[] = shapesArray[i];
+            let shape: Point3D[] = shapesArray[i];
             normalize = MultiPointHandler.normalizePoints(shape, ipc);
             if (lineColor != null && fillColor == null) {
-                kml += ("<LineString>");
+                kml += ("<Polygon>");
                 kml += ("<tessellate>1</tessellate>");
-                kml += ("<altitudeMode>clampToGround</altitudeMode>");
-                kml += ("<coordinates>");
+                kml += ("<altitudeMode>" + altitudeMode + "</altitudeMode>");
+                kml += ("<outerBoundaryIs><LinearRing><coordinates>");
                 let n: int = shape.length;
                 //for (int j = 0; j < shape.length; j++) 
                 for (let j: int = 0; j < n; j++) {
-                    let coord: Point2D = shape[j] as Point2D;
+                    let coord: Point3D = shape[j] as Point3D;
                     let geoCoord: Point2D = ipc.PixelsToGeo(coord);
                     if (normalize) {
                         geoCoord = MultiPointHandler.NormalizeCoordToGECoord(geoCoord);
@@ -517,25 +567,29 @@ export class Shape3DHandler {
 
                     let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
                     let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+                    let altitude: double = coord.getZ();
 
                     kml += (longitude);
                     kml += (",");
                     kml += (latitude);
+                    kml += (",");
+                    kml += (altitude);
                     if (j < shape.length - 1) {
 
                         kml += (" ");
                     }
-
                 }
 
-                kml += ("</coordinates>");
-                kml += ("</LineString>");
+                kml += ("</coordinates></LinearRing></outerBoundaryIs>");
+                kml += ("</Polygon>");
             }
 
             if (fillColor != null) {
 
                 if (i === 0) {
                     kml += ("<Polygon>");
+                    kml += ("<tessellate>1</tessellate>");
+                    kml += ("<altitudeMode>" + altitudeMode + "</altitudeMode>");
                 }
                 //kml += ("<outerBoundaryIs>");
                 if (i === 1 && len > 1) {
@@ -544,38 +598,17 @@ export class Shape3DHandler {
                     kml += ("<outerBoundaryIs>");
                 }
                 kml += ("<LinearRing>");
-                kml += ("<altitudeMode>clampToGround</altitudeMode>");
-                kml += ("<tessellate>1</tessellate>");
                 kml += ("<coordinates>");
 
-                //this section is a workaround for a google earth bug. Issue 417 was closed
-                //for linestrings but they did not fix the smae issue for fills. If Google fixes the issue
-                //for fills then this section will need to be commented or it will induce an error.
-                let lastLongitude: double = Number.MIN_VALUE;
-                if (normalize === false && MultiPointHandler.IsOnePointSymbolCode(symbolCode)) {
-                    let n: int = shape.length;
-                    //for (int j = 0; j < shape.length; j++) 
-                    for (let j: int = 0; j < n; j++) {
-                        let coord: Point2D = shape[j] as Point2D;
-                        let geoCoord: Point2D = ipc.PixelsToGeo(coord);
-                        let longitude: double = geoCoord.getX();
-                        if (lastLongitude !== Number.MIN_VALUE) {
-                            if (Math.abs(longitude - lastLongitude) > 180) {
-                                normalize = true;
-                                break;
-                            }
-                        }
-                        lastLongitude = longitude;
-                    }
-                }
                 let n: int = shape.length;
                 //for (int j = 0; j < shape.length; j++) 
                 for (let j: int = 0; j < n; j++) {
-                    let coord: Point2D = shape[j] as Point2D;
+                    let coord: Point3D = shape[j] as Point3D;
                     let geoCoord: Point2D = ipc.PixelsToGeo(coord);
 
                     let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
                     let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+                    let altitude: double = coord.getZ();
 
                     //fix for fill crossing DTL
                     if (normalize) {
@@ -587,6 +620,8 @@ export class Shape3DHandler {
                     kml += (longitude);
                     kml += (",");
                     kml += (latitude);
+                    kml += (",");
+                    kml += (altitude);
                     if (j < shape.length - 1) {
 
                         kml += (" ");
@@ -616,11 +651,11 @@ export class Shape3DHandler {
     /**
      * 3D Version of {@link MultiPointHandler.LabelToKMLString()}
      */
-    private static LabelToKMLString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean, textColor: Color): string {
+    private static LabelToKMLString(shapeInfo: ShapeInfo3D, ipc: IPointConversion, normalize: boolean, textColor: Color, altitudeMode: string): string {
         let kml: string = "";
 
         //Point2D coord = (Point2D) new Point2D(shapeInfo.getGlyphPosition().getX(), shapeInfo.getGlyphPosition().getY());
-        let coord: Point2D = new Point2D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY()) as Point2D;
+        let coord: Point3D = new Point3D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY(), shapeInfo.getModifierPosition().getZ());
         let geoCoord: Point2D = ipc.PixelsToGeo(coord);
         //M. Deutch 9-26-11
         if (normalize) {
@@ -628,6 +663,7 @@ export class Shape3DHandler {
         }
         let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
         let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+        let altitude: double = coord.getZ();
         let angle: number = Math.round(shapeInfo.getModifierAngle());
 
         let text: string = shapeInfo.getModifierString();
@@ -656,12 +692,14 @@ export class Shape3DHandler {
             kml += ("</LabelStyle>");
             kml += ("</Style>");
             kml += ("<Point>");
-            kml += ("<extrude>1</extrude>");
-            kml += ("<altitudeMode>relativeToGround</altitudeMode>");
+            kml += ("<extrude>0</extrude>");
+            kml += ("<altitudeMode>" + altitudeMode + "</altitudeMode>");
             kml += ("<coordinates>");
             kml += (longitude);
             kml += (",");
             kml += (latitude);
+            kml += (",");
+            kml += (altitude);
             kml += ("</coordinates>");
             kml += ("</Point>");
             kml += ("</Placemark>");
@@ -675,22 +713,18 @@ export class Shape3DHandler {
     /**
      * 3D Version of {@link MultiPointHandler.GeoJSONize()}
      */
-    private static GeoJSONize(shapes: Array<ShapeInfo>, modifiers: Array<ShapeInfo>, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
-
-        let jstr: string = "";
-        let tempModifier: ShapeInfo;
+    private static GeoJSONize(shapes: Array<ShapeInfo3D>, modifiers: Array<ShapeInfo3D>, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
+        let tempModifier: ShapeInfo3D;
         let fc: string = "";//JSON feature collection
 
         fc += ("[");
 
         let len: int = shapes.length;
-        for (let i: int = 0; i < len; i++) 
-        {
-
+        for (let i: int = 0; i < len; i++) {
             let shapesToAdd: string = null;
-            let tempShape:ShapeInfo = shapes[i];
-            if(tempShape != null && tempShape !== undefined) {
-                shapesToAdd = MultiPointHandler.ShapeToGeoJSONString(tempShape, ipc, normalize);
+            let tempShape: ShapeInfo3D = shapes[i];
+            if (tempShape != null && tempShape !== undefined) {
+                shapesToAdd = Shape3DHandler.ShapeToGeoJSONString(tempShape, ipc, normalize);
                 if (shapesToAdd != null && shapesToAdd.length > 0) {
                     fc += (shapesToAdd);
                     if (i < len - 1) {
@@ -707,9 +741,9 @@ export class Shape3DHandler {
 
             let modifiersToAdd: string;
             if (modifiers[j].getModifierImage() != null) {
-                modifiersToAdd = MultiPointHandler.ImageToGeoJSONString(tempModifier, ipc, normalize);
+                modifiersToAdd = Shape3DHandler.ImageToGeoJSONString(tempModifier, ipc, normalize);
             } else {
-                modifiersToAdd = MultiPointHandler.LabelToGeoJSONString(tempModifier, ipc, normalize, textColor, textBackgroundColor);
+                modifiersToAdd = Shape3DHandler.LabelToGeoJSONString(tempModifier, ipc, normalize, textColor, textBackgroundColor);
             }
             if (modifiersToAdd.length > 0) {
                 if (fc.length > 1)
@@ -725,7 +759,7 @@ export class Shape3DHandler {
     /**
      * 3D Version of {@link MultiPointHandler.ShapeToGeoJSONString()}
      */
-    private static ShapeToGeoJSONString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean): string {
+    private static ShapeToGeoJSONString(shapeInfo: ShapeInfo3D, ipc: IPointConversion, normalize: boolean): string {
         let JSONed: string = "";
         let properties: string = "";
         let geometry: string = "";
@@ -751,8 +785,6 @@ export class Shape3DHandler {
 
         if (stroke != null) {
             lineWidth = Math.trunc(stroke.getLineWidth());
-            //lineWidth++;
-            //console.log("lineWidth: " + lineWidth.toString());
         }
 
         //generate JSON properties for feature
@@ -807,26 +839,12 @@ export class Shape3DHandler {
         }
 
         if (lineCap === BasicStroke.CAP_SQUARE) {
-
             properties += ("\"stroke-linecap\":\"square\",");
+        } else if (lineCap === BasicStroke.CAP_ROUND) {
+            properties += ("\"stroke-linecap\":\"round\",");
+        } else if (lineCap === BasicStroke.CAP_BUTT) {
+            properties += ("\"stroke-linecap\":\"butt\",");
         }
-
-        else {
-            if (lineCap === BasicStroke.CAP_ROUND) {
-
-                properties += ("\"stroke-linecap\":\"round\",");
-            }
-
-            else {
-                if (lineCap === BasicStroke.CAP_BUTT) {
-
-                    properties += ("\"stroke-linecap\":\"butt\",");
-                }
-
-            }
-
-        }
-
 
         strokeWidth = lineWidth.toString();
         properties += ("\"stroke-width\":" + strokeWidth);
@@ -849,7 +867,7 @@ export class Shape3DHandler {
 
             //console.log("Pixel Coords:");
             for (let j: int = 0; j < pointList.length; j++) {
-                let coord: Point2D = pointList[j] as Point2D;
+                let coord: Point3D = pointList[j] as Point3D;
                 let geoCoord: Point2D = ipc.PixelsToGeo(coord);
                 //M. Deutch 9-27-11
                 if (normalize) {
@@ -857,6 +875,7 @@ export class Shape3DHandler {
                 }
                 let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
                 let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+                let altitude: double = coord.getZ();
 
                 //fix for fill crossing DTL
                 if (normalize && fillColor != null) {
@@ -868,7 +887,7 @@ export class Shape3DHandler {
                 //diagnostic M. Deutch 10-18-11
                 //set the point as geo so that the 
                 //coord.setLocation(longitude, latitude);
-                coord = new Point2D(longitude, latitude);
+                coord = new Point3D(longitude, latitude, altitude);
                 pointList[j] = coord;
                 //end section
 
@@ -876,6 +895,8 @@ export class Shape3DHandler {
                 geometry += (longitude);
                 geometry += (",");
                 geometry += (latitude);
+                geometry += (",");
+                geometry += (altitude);
                 geometry += ("]");
 
                 if (j < (pointList.length - 1)) {
@@ -903,8 +924,7 @@ export class Shape3DHandler {
     /**
      * 3D Version of {@link MultiPointHandler.ImageToGeoJSONString()}
      */
-    private static ImageToGeoJSONString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean): string {
-
+    private static ImageToGeoJSONString(shapeInfo: ShapeInfo3D, ipc: IPointConversion, normalize: boolean): string {
         let JSONed: string = "";
         let properties: string = "";
         let geometry: string = "";
@@ -912,7 +932,7 @@ export class Shape3DHandler {
         //AffineTransform at = shapeInfo.getAffineTransform();
         //Point2D coord = (Point2D)new Point2D(at.getTranslateX(), at.getTranslateY());
         //Point2D coord = (Point2D) new Point2D(shapeInfo.getGlyphPosition().getX(), shapeInfo.getGlyphPosition().getY());
-        let coord: Point2D = new Point2D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY()) as Point2D;
+        let coord: Point3D = new Point3D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY(), shapeInfo.getModifierPosition().getZ());
         let geoCoord: Point2D = ipc.PixelsToGeo(coord);
         //M. Deutch 9-27-11
         if (normalize) {
@@ -920,6 +940,7 @@ export class Shape3DHandler {
         }
         let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
         let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+        let altitude: double = coord.getZ();
         let angle: double = shapeInfo.getModifierAngle();
         coord.setLocation(longitude, latitude);
 
@@ -943,6 +964,8 @@ export class Shape3DHandler {
             JSONed += (longitude);
             JSONed += (",");
             JSONed += (latitude);
+            JSONed += (",");
+            JSONed += (altitude);
             JSONed += ("]");
             JSONed += ("}}");
 
@@ -956,7 +979,7 @@ export class Shape3DHandler {
     /**
      * 3D Version of {@link MultiPointHandler.LabelToGeoJSONString()}
      */
-    private static LabelToGeoJSONString(shapeInfo: ShapeInfo, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
+    private static LabelToGeoJSONString(shapeInfo: ShapeInfo3D, ipc: IPointConversion, normalize: boolean, textColor: Color, textBackgroundColor: Color): string {
 
         let JSONed: string = "";
         let properties: string = "";
@@ -970,7 +993,7 @@ export class Shape3DHandler {
         //AffineTransform at = shapeInfo.getAffineTransform();
         //Point2D coord = (Point2D)new Point2D(at.getTranslateX(), at.getTranslateY());
         //Point2D coord = (Point2D) new Point2D(shapeInfo.getGlyphPosition().getX(), shapeInfo.getGlyphPosition().getY());
-        let coord: Point2D = new Point2D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY()) as Point2D;
+        let coord: Point3D = new Point3D(shapeInfo.getModifierPosition().getX(), shapeInfo.getModifierPosition().getY(), shapeInfo.getModifierPosition().getZ());
         let geoCoord: Point2D = ipc.PixelsToGeo(coord);
         //M. Deutch 9-27-11
         if (normalize) {
@@ -978,6 +1001,7 @@ export class Shape3DHandler {
         }
         let latitude: double = Math.round(geoCoord.getY() * 100000000.0) / 100000000.0;
         let longitude: double = Math.round(geoCoord.getX() * 100000000.0) / 100000000.0;
+        let altitude: double = coord.getZ();
         let angle: double = shapeInfo.getModifierAngle();
         coord.setLocation(longitude, latitude);
 
@@ -990,17 +1014,11 @@ export class Shape3DHandler {
         let strJustify: string = "left";
         if (justify === 0) {
             strJustify = "left";
-        } else {
-            if (justify === 1) {
-                strJustify = "center";
-            } else {
-                if (justify === 2) {
-                    strJustify = "right";
-                }
-            }
-
+        } else if (justify === 1) {
+            strJustify = "center";
+        } else if (justify === 2) {
+            strJustify = "right";
         }
-
 
         let RS: RendererSettings = RendererSettings.getInstance();
 
@@ -1042,6 +1060,8 @@ export class Shape3DHandler {
             JSONed += (longitude);
             JSONed += (",");
             JSONed += (latitude);
+            JSONed += (",");
+            JSONed += (altitude);
             JSONed += ("]");
             JSONed += ("}}");
 

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -81,6 +81,9 @@ export class Shape3DHandler {
             symbolAttributes.set(MilStdAttributes.FillColor, defaultColor.toHexString(true));
         }
 
+        if (altitudeMode == undefined || altitudeMode == "clampToGround")
+            altitudeMode = "absolute"
+
         if (!JavaRendererUtilities.is3dSymbol(symbolCode)) {
             const basicID: string = SymbolUtilities.getBasicSymbolID(symbolCode);
             const errorMsg = "Basic ID: " + basicID + " is not a 3D Symbol";
@@ -486,6 +489,9 @@ export class Shape3DHandler {
             defaultColor.setAlpha(170);
             symbolAttributes.set(MilStdAttributes.FillColor, defaultColor.toHexString(true));
         }
+
+        if (altitudeMode == undefined || altitudeMode == "clampToGround")
+            altitudeMode = "absolute"
 
         for (let i: int = 0; i < len; i++) {
             let coordPair: string[] = coordinates[i].split(",");

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -383,7 +383,7 @@ export class Shape3DHandler {
                 if (textColor == null)
                     textColor = mSymbol.getLineColor();
 
-                jsonOutput = Shape3DHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, altitudeMode);
+                jsonOutput = Shape3DHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, altitudeMode, mSymbol.get_WasClipped());
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
                 jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
                 jsonContent = Shape3DHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
@@ -708,7 +708,7 @@ export class Shape3DHandler {
                 if (textColor == null)
                     textColor = mSymbol.getLineColor();
 
-                jsonOutput = Shape3DHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, altitudeMode);
+                jsonOutput = Shape3DHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, altitudeMode, mSymbol.get_WasClipped());
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
                 jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
                 jsonContent = Shape3DHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
@@ -763,21 +763,21 @@ export class Shape3DHandler {
         ipc: IPointConversion,
         normalize: boolean,
         textColor: Color,
-        altitudeMode: string): string {
-
+        altitudeMode: string, 
+        wasClipped: boolean): string {
         let kml: string = "";
-
         let tempModifier: ShapeInfo3D;
-
-        let cdataStart: string = "<![CDATA[";
-        let cdataEnd: string = "]]>";
-
         let len: int = shapes.length;
         kml += ("<Folder id=\"" + id + "\">");
-        kml += ("<name>" + cdataStart + name + cdataEnd + "</name>");
+        kml += ("<name>" + name + "</name>");
         kml += ("<visibility>1</visibility>");
+        kml += ("<description>" + description + "</description>");
+        kml += ("<ExtendedData>");
+        kml += ("<Data name=\"symbolID\"><value>" + symbolCode + "</value></Data>");
+        kml += ("<Data name=\"wasClipped\"><value>" + wasClipped + "</value></Data>");
+        kml += ("</ExtendedData>");
         for (let i: int = 0; i < len; i++) {
-            let shapesToAdd: string = Shape3DHandler.ShapeToKMLString(name, description, symbolCode, shapes[i], ipc, normalize, altitudeMode);
+            let shapesToAdd: string = Shape3DHandler.ShapeToKMLString(shapes[i], ipc, normalize, altitudeMode);
             kml += (shapesToAdd);
         }
 
@@ -802,34 +802,19 @@ export class Shape3DHandler {
     /**
      * 3D Version of {@link MultiPointHandler.ShapeToKMLString()}
      */
-    private static ShapeToKMLString(name: string,
-        description: string,
-        symbolCode: string,
-        shapeInfo: ShapeInfo3D,
+    private static ShapeToKMLString(shapeInfo: ShapeInfo3D,
         ipc: IPointConversion,
         normalize: boolean,
         altitudeMode: string): string {
-
         let kml: string = "";
-
         let lineColor: Color;
         let fillColor: Color;
         let googleLineColor: string;
         let googleFillColor: string;
-
-        //String lineStyleId = "lineColor";
-
         let stroke: BasicStroke;
         let lineWidth: int = 4;
 
-        symbolCode = JavaRendererUtilities.normalizeSymbolCode(symbolCode);
-
-        let cdataStart: string = "<![CDATA[";
-        let cdataEnd: string = "]]>";
-
-        kml += ("<Placemark>");//("<Placemark id=\"" + id + "_mg" + "\">");
-        kml += ("<description>" + cdataStart + "<b>" + name + "</b><br/>" + "\n" + description + cdataEnd + "</description>");
-        //kml += ("<Style id=\"" + lineStyleId + "\">");
+        kml += ("<Placemark>");
         kml += ("<Style>");
 
         lineColor = shapeInfo.getLineColor();

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -25,6 +25,7 @@ import { Modifiers } from "../../renderer/utilities/Modifiers";
 import { SymbolUtilities } from "../../renderer/utilities/SymbolUtilities";
 import { ShapeInfo } from "../../renderer/utilities/ShapeInfo";
 import { Font } from "../../graphics2d/Font";
+import { Rectangle2D } from "../../graphics2d/Rectangle2D";
 
 export class Shape3DHandler {
     /**
@@ -73,7 +74,7 @@ export class Shape3DHandler {
         if (symbolAttributes.get(MilStdAttributes.FillColor) == null) {
             var defaultColor = SymbolUtilities.getFillColorOfAffiliation(symbolCode);
             if (defaultColor == null) {
-                defaultColor = new Color(Color.BLACK);
+                defaultColor = new Color(Color.WHITE);
             }
             defaultColor.setAlpha(170);
             symbolAttributes.set(MilStdAttributes.FillColor, defaultColor.toHexString(true));
@@ -448,8 +449,7 @@ export class Shape3DHandler {
         bbox: string,
         symbolModifiers: Map<string, string>,
         symbolAttributes: Map<string, string>,
-        format: int): string
-    {
+        format: int): string {
         let normalize: boolean = true;
         //Double controlLat = 0.0;
         //Double controlLong = 0.0;
@@ -460,14 +460,31 @@ export class Shape3DHandler {
 
         let rect: Rectangle;
         let coordinates: string[] = controlPoints.split(" ");
-        let shapes: Array<ShapeInfo> = new Array<ShapeInfo>();
-        let modifiers: Array<ShapeInfo> = new Array<ShapeInfo>();
+        let shapes: Array<ShapeInfo3D> = new Array<ShapeInfo3D>();
+        let modifiers: Array<ShapeInfo3D> = new Array<ShapeInfo3D>();
         //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
         let geoCoords: Array<Point2D> = new Array<Point2D>();
         let len: int = coordinates.length;
         //diagnostic create geoCoords here
         let coordsUL: Point2D = null;
         const symbolCode = "";
+
+        // 3D default colors
+        if (symbolAttributes.get(MilStdAttributes.LineColor) == null) {
+            var defaultColor = SymbolUtilities.getLineColorOfAffiliation(symbolCode);
+            if (defaultColor == null) {
+                defaultColor = new Color(Color.BLACK);
+            }
+            symbolAttributes.set(MilStdAttributes.LineColor, defaultColor.toHexString());
+        }
+        if (symbolAttributes.get(MilStdAttributes.FillColor) == null) {
+            var defaultColor = SymbolUtilities.getFillColorOfAffiliation(symbolCode);
+            if (defaultColor == null) {
+                defaultColor = new Color(Color.WHITE);
+            }
+            defaultColor.setAlpha(170);
+            symbolAttributes.set(MilStdAttributes.FillColor, defaultColor.toHexString(true));
+        }
 
         for (let i: int = 0; i < len; i++) {
             let coordPair: string[] = coordinates[i].split(",");
@@ -614,46 +631,89 @@ export class Shape3DHandler {
             mSymbol.setSymbolShapes(shapeInfos);
             mSymbol.setModifierShapes(modifierShapeInfos);
             mSymbol.set_WasClipped(tg.get_WasClipped());
-            shapes = mSymbol.getSymbolShapes();
-            modifiers = mSymbol.getModifierShapes();
 
-            if (format === WebRenderer.OUTPUT_FORMAT_JSON) {
-                jsonOutput += ("{\"type\":\"symbol\",");
-                jsonContent = MultiPointHandler.JSONize(shapes, modifiers, ipc, true, normalize);
-                jsonOutput += (jsonContent);
-                jsonOutput += ("}");
-            } else if (format === WebRenderer.OUTPUT_FORMAT_KML) {
+            // Convert 2D shape to 3D
+            // Confirm there are at least two altitudes per shape
+            let altitudes = mSymbol.getModifiers_AM_AN_X(Modifiers.X_ALTITUDE_DEPTH);
+            if (altitudes.length === 1) {
+                altitudes = [0, altitudes[0]];
+            }
+            const lastAlt = altitudes[altitudes.length - 1];
+            const nextToLastAlt = altitudes[altitudes.length - 2];
+            while (altitudes.length < mSymbol.getSymbolShapes().length * 2) {
+                altitudes.push(nextToLastAlt, lastAlt);
+            }
+            for (let shapeIndex = 0; shapeIndex < mSymbol.getSymbolShapes().length; shapeIndex++) {
+                const minAlt = altitudes[shapeIndex * 2];
+                const maxAlt = altitudes[(shapeIndex * 2) + 1];
+                const oldShape = mSymbol.getSymbolShapes()[shapeIndex];
+
+                var bottomShape = new ShapeInfo3D();
+                bottomShape.setShapeType(oldShape.getShapeType());
+                bottomShape.setStroke(oldShape.getStroke());
+                bottomShape.setLineColor(oldShape.getLineColor());
+                bottomShape.setFillColor(oldShape.getFillColor());
+                bottomShape.setPatternFillImage(oldShape.getPatternFillImageInfo());
+                bottomShape.setPolylines([]);
+                var topShape = new ShapeInfo3D();
+                topShape.setShapeType(oldShape.getShapeType());
+                topShape.setStroke(oldShape.getStroke());
+                topShape.setLineColor(oldShape.getLineColor());
+                topShape.setFillColor(oldShape.getFillColor());
+                topShape.setPatternFillImage(oldShape.getPatternFillImageInfo());
+                topShape.setPolylines([]);
+
+                for (let polyLineIndex = 0; polyLineIndex < oldShape.getPolylines().length; polyLineIndex++) {
+                    const polyline = oldShape.getPolylines()[polyLineIndex];
+                    bottomShape.getPolylines().push([]);
+                    topShape.getPolylines().push([]);
+                    for (let ptIndex = 0; ptIndex < polyline.length; ptIndex++) {
+                        const pt = polyline[ptIndex];
+                        const pt2 = polyline[(ptIndex + 1) % polyline.length];
+                        bottomShape.getPolylines()[polyLineIndex].push(new Point3D(pt, minAlt));
+                        topShape.getPolylines()[polyLineIndex].push(new Point3D(pt, maxAlt));
+
+                        var sideShape = new ShapeInfo3D();
+                        sideShape.setShapeType(oldShape.getShapeType());
+                        sideShape.setStroke(oldShape.getStroke());
+                        sideShape.setLineColor(oldShape.getLineColor());
+                        sideShape.setFillColor(oldShape.getFillColor());
+                        sideShape.setPatternFillImage(oldShape.getPatternFillImageInfo());
+                        sideShape.setPolylines([[new Point3D(pt, minAlt), new Point3D(pt2, minAlt), new Point3D(pt2, maxAlt), new Point3D(pt, maxAlt), new Point3D(pt, minAlt)]]);
+                        shapes.push(sideShape);
+                    }
+                }
+                shapes.push(bottomShape);
+                shapes.push(topShape);
+            }
+
+            const modifierAlt = Math.max(...altitudes.splice(0, mSymbol.getSymbolShapes().length * 2));
+            for (const oldShape of mSymbol.getModifierShapes()) {
+                var modShape = new ShapeInfo3D();
+                modShape.setModifierString(oldShape.getModifierString());
+                modShape.setModifierPosition(new Point3D(oldShape.getModifierPosition(), modifierAlt));
+                modShape.setModifierAngle(oldShape.getModifierAngle());
+                modShape.setTextJustify(oldShape.getTextJustify());
+                modShape.setModifierImage(oldShape.getModifierImageInfo());
+
+                modifiers.push(modShape);
+            }
+
+            if (format === WebRenderer.OUTPUT_FORMAT_KML) {
                 var textColor = mSymbol.getTextColor();
-                if(textColor==null)
-                    textColor=mSymbol.getLineColor();
+                if (textColor == null)
+                    textColor = mSymbol.getLineColor();
 
-                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
-                jsonOutput += jsonContent;
+                jsonOutput = Shape3DHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, altitudeMode);
             } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
-                /*
                 jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
-                jsonContent = GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
-                jsonOutput += (jsonContent);
-                jsonOutput += (",\"properties\":{\"id\":\"");
-                jsonOutput += (id);
-                jsonOutput += ("\",\"name\":\"");
-                jsonOutput += (name);
-                jsonOutput += ("\",\"description\":\"");
-                jsonOutput += (description);
-                jsonOutput += ("\",\"symbolID\":\"");
-                jsonOutput += (symbolCode);
-                jsonOutput += ("\",\"wasClipped\":\"");
-                jsonOutput += (mSymbol.get_WasClipped()).toString();
-                jsonOutput += ("\"}}");         */
-
-                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
-                jsonContent = MultiPointHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonContent = Shape3DHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
                 jsonOutput += (jsonContent);
 
                 //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
                 jsonOutput = jsonOutput.slice(0, -1);
                 if (jsonContent.length > 2)
-                    jsonOutput += ","
+                    jsonOutput += ",";
                 jsonOutput += ("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
 
                 jsonOutput += (",\"properties\":{\"id\":\"");
@@ -666,14 +726,7 @@ export class Shape3DHandler {
                 jsonOutput += (symbolCode);
                 jsonOutput += ("\",\"wasClipped\":\"");
                 jsonOutput += (mSymbol.get_WasClipped()).toString();
-                //jsonOutput += ("\"}}");
-
                 jsonOutput += ("\"}}]}");
-            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOSVG) {
-                let textColor = mSymbol.getTextColor() ? mSymbol.getTextColor().toHexString(false) : "";
-                let backgroundColor = mSymbol.getTextBackgroundColor() ? mSymbol.getTextBackgroundColor().toHexString(false) : "";
-                //returns an svg with a geoTL and geoBR value to use to place the canvas on the map
-                jsonOutput = MultiPointHandlerSVG.GeoSVGize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, backgroundColor, mSymbol.get_WasClipped());
             }
         } catch (exc) {
             if (exc instanceof Error) {
@@ -684,38 +737,13 @@ export class Shape3DHandler {
                 jsonOutput += (st);
                 jsonOutput += ("\"}");
 
-                ErrorLogger.LogException("MultiPointHandler", "RenderBasicSymbol", exc);
+                ErrorLogger.LogException("Shape3DHandler", "RenderBasic3DShape", exc);
             } else {
                 throw exc;
             }
         }
 
-        /*
-        let debug: boolean = false;
-        if (debug === true) {
-            console.log("Symbol Code: " + symbolCode);
-            console.log("Scale: " + scale);
-            console.log("BBOX: " + bbox);
-            if (controlPoints != null) {
-                console.log("Geo Points: " + controlPoints);
-            }
-            if (tgl != null && tgl.get_Pixels() != null)//pixels != null
-            {
-                console.log("Pixel: " + tgl.get_Pixels().toString());
-            }
-            if (bbox != null) {
-                console.log("geo bounds: " + bbox);
-            }
-            if (rect != null) {
-                console.log("pixel bounds: " + rect.toString());
-            }
-            if (jsonOutput != null) {
-                console.log(jsonOutput.toString());
-            }
-        }
-            */
-
-        ErrorLogger.LogMessage("MultiPointHandler", "RenderBasicShape()", "exit RenderBasicShape", LogLevel.FINER);
+        ErrorLogger.LogMessage("Shape3DHandler", "RenderBasic3DShape()", "exit RenderBasic3DShape", LogLevel.FINER);
         return jsonOutput.toString();
     }
 

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -26,6 +26,7 @@ import { SymbolUtilities } from "../../renderer/utilities/SymbolUtilities";
 import { ShapeInfo } from "../../renderer/utilities/ShapeInfo";
 import { Font } from "../../graphics2d/Font";
 import { Rectangle2D } from "../../graphics2d/Rectangle2D";
+import { Basic3DShapes } from "./utilities/Basic3DShapes";
 
 export class Shape3DHandler {
     /**
@@ -637,6 +638,9 @@ export class Shape3DHandler {
             let altitudes = mSymbol.getModifiers_AM_AN_X(Modifiers.X_ALTITUDE_DEPTH);
             if (altitudes.length === 1) {
                 altitudes = [0, altitudes[0]];
+            }
+            if (basicShapeType === Basic3DShapes.ROUTE){
+                altitudes = altitudes.slice(0, 2)
             }
             const lastAlt = altitudes[altitudes.length - 1];
             const nextToLastAlt = altitudes[altitudes.length - 2];

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -476,18 +476,10 @@ export class Shape3DHandler {
 
         // 3D default colors
         if (symbolAttributes.get(MilStdAttributes.LineColor) == null) {
-            var defaultColor = SymbolUtilities.getLineColorOfAffiliation(symbolCode);
-            if (defaultColor == null) {
-                defaultColor = new Color(Color.BLACK);
-            }
-            symbolAttributes.set(MilStdAttributes.LineColor, defaultColor.toHexString());
+            symbolAttributes.set(MilStdAttributes.LineColor, Color.BLACK.toHexString());
         }
         if (symbolAttributes.get(MilStdAttributes.FillColor) == null) {
-            var defaultColor = SymbolUtilities.getFillColorOfAffiliation(symbolCode);
-            if (defaultColor == null) {
-                defaultColor = new Color(Color.WHITE);
-            }
-            defaultColor.setAlpha(170);
+            var defaultColor = new Color(255, 255, 255, 170);
             symbolAttributes.set(MilStdAttributes.FillColor, defaultColor.toHexString(true));
         }
 

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -365,16 +365,17 @@ export class Shape3DHandler {
                 shapes.push(topShape);
             }
 
-            const modifierAlt = Math.max(...altitudes.slice(0, mSymbol.getSymbolShapes().length * 2));
-            for (const oldShape of mSymbol.getModifierShapes()) {
-                var modShape = new ShapeInfo3D();
-                modShape.setModifierString(oldShape.getModifierString());
-                modShape.setModifierPosition(new Point3D(oldShape.getModifierPosition(), modifierAlt));
-                modShape.setModifierAngle(oldShape.getModifierAngle());
-                modShape.setTextJustify(oldShape.getTextJustify());
-                modShape.setModifierImage(oldShape.getModifierImageInfo());
-
-                modifiers.push(modShape);
+            if (mSymbol.getSymbolShapes().length > 0 && mSymbol.getModifierShapes().length > 0) {
+                const modifierAlt = Math.max(...altitudes.slice(0, mSymbol.getSymbolShapes().length * 2));
+                for (const oldShape of mSymbol.getModifierShapes()) {
+                    var modShape = new ShapeInfo3D();
+                    modShape.setModifierString(oldShape.getModifierString());
+                    modShape.setModifierPosition(new Point3D(oldShape.getModifierPosition(), modifierAlt));
+                    modShape.setModifierAngle(oldShape.getModifierAngle());
+                    modShape.setTextJustify(oldShape.getTextJustify());
+                    modShape.setModifierImage(oldShape.getModifierImageInfo());
+                    modifiers.push(modShape);
+                }
             }
 
             if (format === WebRenderer.OUTPUT_FORMAT_KML) {
@@ -697,16 +698,17 @@ export class Shape3DHandler {
                 shapes.push(topShape);
             }
 
-            const modifierAlt = Math.max(...altitudes.slice(0, mSymbol.getSymbolShapes().length * 2));
-            for (const oldShape of mSymbol.getModifierShapes()) {
-                var modShape = new ShapeInfo3D();
-                modShape.setModifierString(oldShape.getModifierString());
-                modShape.setModifierPosition(new Point3D(oldShape.getModifierPosition(), modifierAlt));
-                modShape.setModifierAngle(oldShape.getModifierAngle());
-                modShape.setTextJustify(oldShape.getTextJustify());
-                modShape.setModifierImage(oldShape.getModifierImageInfo());
-
-                modifiers.push(modShape);
+            if (mSymbol.getSymbolShapes().length > 0 && mSymbol.getModifierShapes().length > 0) {
+                const modifierAlt = Math.max(...altitudes.slice(0, mSymbol.getSymbolShapes().length * 2));
+                for (const oldShape of mSymbol.getModifierShapes()) {
+                    var modShape = new ShapeInfo3D();
+                    modShape.setModifierString(oldShape.getModifierString());
+                    modShape.setModifierPosition(new Point3D(oldShape.getModifierPosition(), modifierAlt));
+                    modShape.setModifierAngle(oldShape.getModifierAngle());
+                    modShape.setTextJustify(oldShape.getTextJustify());
+                    modShape.setModifierImage(oldShape.getModifierImageInfo());
+                    modifiers.push(modShape);
+                }
             }
 
             if (format === WebRenderer.OUTPUT_FORMAT_KML) {

--- a/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/Shape3DHandler.ts
@@ -421,6 +421,305 @@ export class Shape3DHandler {
     }
 
     /**
+     *
+     * @param id
+     * @param name
+     * @param description
+     * @param basicShapeType
+     * @param controlPoints
+     * @param scale
+     * @param bbox
+     * @param symbolModifiers {@link Map}, keyed using constants from
+     * Modifiers. Pass in comma delimited String for modifiers with multiple
+     * values like AM, AN &amp; X
+     * @param symbolAttributes {@link Map}, keyed using constants from
+     * MilStdAttributes. pass in double[] for AM, AN and X; Strings for the
+     * rest.
+     * @param format
+     * @return
+     */
+    public static RenderBasic3DShape(id: string,
+        name: string,
+        description: string,
+        basicShapeType: int,
+        controlPoints: string,
+        altitudeMode: string,
+        scale: number,
+        bbox: string,
+        symbolModifiers: Map<string, string>,
+        symbolAttributes: Map<string, string>,
+        format: int): string
+    {
+        let normalize: boolean = true;
+        //Double controlLat = 0.0;
+        //Double controlLong = 0.0;
+        //Double metPerPix = GeoPixelConversion.metersPerPixel(scale);
+        //String bbox2=getBoundingRectangle(controlPoints,bbox);
+        let jsonOutput: string = "";
+        let jsonContent: string = "";
+
+        let rect: Rectangle;
+        let coordinates: string[] = controlPoints.split(" ");
+        let shapes: Array<ShapeInfo> = new Array<ShapeInfo>();
+        let modifiers: Array<ShapeInfo> = new Array<ShapeInfo>();
+        //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
+        let geoCoords: Array<Point2D> = new Array<Point2D>();
+        let len: int = coordinates.length;
+        //diagnostic create geoCoords here
+        let coordsUL: Point2D = null;
+        const symbolCode = "";
+
+        for (let i: int = 0; i < len; i++) {
+            let coordPair: string[] = coordinates[i].split(",");
+            let latitude: number = parseFloat(coordPair[1].trim());
+            let longitude: number = parseFloat(coordPair[0].trim());
+            geoCoords.push(new Point2D(longitude, latitude));
+        }
+        let tgPoints: Array<POINT2>;
+        let ipc: IPointConversion;
+
+        //Deutch moved section 6-29-11
+        let left: number = 0.0;
+        let right: number = 0.0;
+        let top: number = 0.0;
+        let bottom: number = 0.0;
+        let temp: Point2D;
+        let ptGeoUL: Point2D;
+        let width: int = 0;
+        let height: int = 0;
+        let leftX: int = 0;
+        let topY: int = 0;
+        let bottomY: int = 0;
+        let rightX: int = 0;
+        let j: int = 0;
+        let bboxCoords: Array<Point2D>;
+        if (bbox != null && bbox !== "") {
+            let bounds: string[];
+            if (bbox.includes(" "))//trapezoid
+            {
+                bboxCoords = new Array<Point2D>();
+                let x: double = 0;
+                let y: double = 0;
+                let coords: string[] = bbox.split(" ");
+                let arrCoord: string[];
+                for (let coord of coords) {
+                    arrCoord = coord.split(",");
+                    x = parseFloat(arrCoord[0]);
+                    y = parseFloat(arrCoord[1]);
+                    bboxCoords.push(new Point2D(x, y));
+                }
+                //use the upper left corner of the MBR containing geoCoords
+                //to set the converter
+                ptGeoUL = MultiPointHandler.getGeoUL(bboxCoords);
+                left = ptGeoUL.getX();
+                top = ptGeoUL.getY();
+                let bbox2: string = MultiPointHandler.getBboxFromCoords(bboxCoords);
+                scale = MultiPointHandler.getReasonableScale(bbox2, scale);
+                ipc = new PointConverter(left, top, scale);
+                let ptPixels: Point2D;
+                let ptGeo: Point2D;
+                let n: int = bboxCoords.length;
+                //for (j = 0; j < bboxCoords.length; j++) 
+                for (j = 0; j < n; j++) {
+                    ptGeo = bboxCoords[j];
+                    ptPixels = ipc.GeoToPixels(ptGeo);
+                    x = ptPixels.getX();
+                    y = ptPixels.getY();
+                    if (x < 20) {
+                        x = 20;
+                    }
+                    if (y < 20) {
+                        y = 20;
+                    }
+                    ptPixels.setLocation(x, y);
+                    //end section
+                    bboxCoords[j] = ptPixels;
+                }
+            } else//rectangle
+            {
+                bounds = bbox.split(",");
+                left = parseFloat(bounds[0]);
+                right = parseFloat(bounds[2]);
+                top = parseFloat(bounds[3]);
+                bottom = parseFloat(bounds[1]);
+                scale = MultiPointHandler.getReasonableScale(bbox, scale);
+                ipc = new PointConverter(left, top, scale);
+            }
+
+            let pt2d: Point2D;
+            if (bboxCoords == null) {
+                pt2d = new Point2D(left, top);
+                temp = ipc.GeoToPixels(pt2d);
+
+                leftX = temp.getX() as int;
+                topY = temp.getY() as int;
+
+                pt2d = new Point2D(right, bottom);
+                temp = ipc.GeoToPixels(pt2d);
+
+                bottomY = temp.getY() as int;
+                rightX = temp.getX() as int;
+
+                width = Math.abs(rightX - leftX) as int;
+                height = Math.abs(bottomY - topY) as int;
+
+                rect = new Rectangle(leftX, topY, width, height);
+            }
+        } else {
+            rect = null;
+        }
+
+        if (ipc == null) {
+            let ptCoordsUL: Point2D = MultiPointHandler.getGeoUL(geoCoords);
+            ipc = new PointConverter(ptCoordsUL.getX(), ptCoordsUL.getY(), scale);
+        }
+        
+        let geoCoords2: Array<Point2D> = new Array<Point2D>();
+        geoCoords2.push(new Point2D(left, top));
+        geoCoords2.push(new Point2D(right, bottom));
+
+        //        if (normalize) {
+        //            NormalizeGECoordsToGEExtents(0, 360, geoCoords2);
+        //        }
+
+        try {
+
+            //String fillColor = null;
+            let mSymbol: MilStdSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
+            
+            if (format == WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                // Use dash array and hatch pattern fill for SVG output
+                symbolAttributes.set(MilStdAttributes.UseDashArray, 'true')
+                symbolAttributes.set(MilStdAttributes.UsePatternFill, "true")
+            }
+
+            if (symbolModifiers != null || symbolAttributes != null) {
+                MultiPointHandler.populateModifiers(symbolModifiers, symbolAttributes, mSymbol);
+            } else {
+                mSymbol.setFillColor(null);
+            }
+
+            let tg: TGLight = clsRenderer.createTGLightFromMilStdSymbolBasicShape(mSymbol, ipc, basicShapeType);
+            let shapeInfos: Array<ShapeInfo> = [];
+            let modifierShapeInfos: Array<ShapeInfo> = [];
+            let clipArea: Point2D[] | Rectangle | Rectangle2D;
+            if (bboxCoords == null) {
+                clipArea = rect;
+            } else {
+                clipArea = bboxCoords;
+            }
+            if (clsRenderer.intersectsClipArea(tg, ipc, clipArea)) {
+                clsRenderer.render_GE(tg, shapeInfos, modifierShapeInfos, ipc, clipArea);
+            }
+            mSymbol.setSymbolShapes(shapeInfos);
+            mSymbol.setModifierShapes(modifierShapeInfos);
+            mSymbol.set_WasClipped(tg.get_WasClipped());
+            shapes = mSymbol.getSymbolShapes();
+            modifiers = mSymbol.getModifierShapes();
+
+            if (format === WebRenderer.OUTPUT_FORMAT_JSON) {
+                jsonOutput += ("{\"type\":\"symbol\",");
+                jsonContent = MultiPointHandler.JSONize(shapes, modifiers, ipc, true, normalize);
+                jsonOutput += (jsonContent);
+                jsonOutput += ("}");
+            } else if (format === WebRenderer.OUTPUT_FORMAT_KML) {
+                var textColor = mSymbol.getTextColor();
+                if(textColor==null)
+                    textColor=mSymbol.getLineColor();
+
+                jsonContent = MultiPointHandler.KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonOutput += jsonContent;
+            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOJSON) {
+                /*
+                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput += (jsonContent);
+                jsonOutput += (",\"properties\":{\"id\":\"");
+                jsonOutput += (id);
+                jsonOutput += ("\",\"name\":\"");
+                jsonOutput += (name);
+                jsonOutput += ("\",\"description\":\"");
+                jsonOutput += (description);
+                jsonOutput += ("\",\"symbolID\":\"");
+                jsonOutput += (symbolCode);
+                jsonOutput += ("\",\"wasClipped\":\"");
+                jsonOutput += (mSymbol.get_WasClipped()).toString();
+                jsonOutput += ("\"}}");         */
+
+                jsonOutput += ("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = MultiPointHandler.GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput += (jsonContent);
+
+                //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
+                jsonOutput = jsonOutput.slice(0, -1);
+                if (jsonContent.length > 2)
+                    jsonOutput += ","
+                jsonOutput += ("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+
+                jsonOutput += (",\"properties\":{\"id\":\"");
+                jsonOutput += (id);
+                jsonOutput += ("\",\"name\":\"");
+                jsonOutput += (name);
+                jsonOutput += ("\",\"description\":\"");
+                jsonOutput += (description);
+                jsonOutput += ("\",\"symbolID\":\"");
+                jsonOutput += (symbolCode);
+                jsonOutput += ("\",\"wasClipped\":\"");
+                jsonOutput += (mSymbol.get_WasClipped()).toString();
+                //jsonOutput += ("\"}}");
+
+                jsonOutput += ("\"}}]}");
+            } else if (format === WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                let textColor = mSymbol.getTextColor() ? mSymbol.getTextColor().toHexString(false) : "";
+                let backgroundColor = mSymbol.getTextBackgroundColor() ? mSymbol.getTextBackgroundColor().toHexString(false) : "";
+                //returns an svg with a geoTL and geoBR value to use to place the canvas on the map
+                jsonOutput = MultiPointHandlerSVG.GeoSVGize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, backgroundColor, mSymbol.get_WasClipped());
+            }
+        } catch (exc) {
+            if (exc instanceof Error) {
+                let st: string = JavaRendererUtilities.getStackTrace(exc);
+                jsonOutput = "";
+                jsonOutput += ("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + ": " + "- ");
+                jsonOutput += (exc.message + " - ");
+                jsonOutput += (st);
+                jsonOutput += ("\"}");
+
+                ErrorLogger.LogException("MultiPointHandler", "RenderBasicSymbol", exc);
+            } else {
+                throw exc;
+            }
+        }
+
+        /*
+        let debug: boolean = false;
+        if (debug === true) {
+            console.log("Symbol Code: " + symbolCode);
+            console.log("Scale: " + scale);
+            console.log("BBOX: " + bbox);
+            if (controlPoints != null) {
+                console.log("Geo Points: " + controlPoints);
+            }
+            if (tgl != null && tgl.get_Pixels() != null)//pixels != null
+            {
+                console.log("Pixel: " + tgl.get_Pixels().toString());
+            }
+            if (bbox != null) {
+                console.log("geo bounds: " + bbox);
+            }
+            if (rect != null) {
+                console.log("pixel bounds: " + rect.toString());
+            }
+            if (jsonOutput != null) {
+                console.log(jsonOutput.toString());
+            }
+        }
+            */
+
+        ErrorLogger.LogMessage("MultiPointHandler", "RenderBasicShape()", "exit RenderBasicShape", LogLevel.FINER);
+        return jsonOutput.toString();
+    }
+
+    /**
      * 3D Version of {@link MultiPointHandler.KMLize()}
      */
     private static KMLize(id: string,

--- a/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
@@ -633,7 +633,7 @@ export class WebRenderer /* extends Applet */ {
         } catch (ea) {
             if (ea instanceof Error) {
                 output = "{\"type\":'error',error:'There was an error creating the MilStdSymbol - " + ea.toString() + "'}";
-                ErrorLogger.LogException("WebRenderer", "RenderSymbol", ea, LogLevel.WARNING);
+                ErrorLogger.LogException("WebRenderer", "RenderBasicShape", ea, LogLevel.WARNING);
             } else {
                 throw ea;
             }

--- a/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
@@ -25,6 +25,7 @@ import { mdlGeodesic } from "../../JavaTacticalRenderer/mdlGeodesic"
 import { POINT2 } from "../../JavaLineArray/POINT2";
 import { ref } from "../../JavaLineArray/ref"
 import { BasicShapes } from "../../JavaLineArray/BasicShapes";
+import { Shape3DHandler } from "./Shape3DHandler";
 
 
 /**
@@ -249,28 +250,39 @@ export class WebRenderer /* extends Applet */ {
 
             JavaRendererUtilities.addAltModeToModifiersString(attributes, altitudeMode);
 
-            
-            output = MultiPointHandler.RenderSymbol(id, name, description, symbolCode, controlPoints,
-                scale, bbox, modifiers, attributes, format);
+            if (altitudeMode !== "clampToGround"
+                && (format === WebRenderer.OUTPUT_FORMAT_KML || format === WebRenderer.OUTPUT_FORMAT_GEOJSON)
+                && JavaRendererUtilities.is3dSymbol(symbolCode)
+                && modifiers.get(Modifiers.X_ALTITUDE_DEPTH)) {
+                if (!(altitudeMode))
+                    altitudeMode = "absolute";
 
-            //DEBUGGING
-            if (ErrorLogger.getLevel().intValue() <= LogLevel.FINER.intValue()) {
-                console.log("");
-                let sb: string = "";
-                sb += ("\nID: " + id + "\n");
-                sb += ("Name: " + name + "\n");
-                sb += ("Description: " + description + "\n");
-                sb += ("SymbolID: " + symbolCode + "\n");
-                sb += ("Scale: " + scale.toString() + "\n");
-                sb += ("BBox: " + bbox + "\n");
-                sb += ("Coords: " + controlPoints + "\n");
-                sb += ("Modifiers: " + modifiers + "\n");
-                ErrorLogger.LogMessage("WebRenderer", "RenderSymbol", sb.toString(), LogLevel.FINER);
+                output = this.RenderMilStd3dSymbol(id, name, description, symbolCode, controlPoints, altitudeMode, scale, bbox, modifiers, attributes, format);
             }
-            if (ErrorLogger.getLevel().intValue() <= LogLevel.FINEST.intValue()) {
-                let briefOutput: string = output.replaceAll("</Placemark>", "</Placemark>\n");
-                briefOutput = output.replaceAll("(?s)<description[^>]*>.*?</description>", "<description></description>");
-                ErrorLogger.LogMessage("WebRenderer", "RenderSymbol", "Output:\n" + briefOutput, LogLevel.FINEST);
+
+            if (output === "") {
+                output = MultiPointHandler.RenderSymbol(id, name, description, symbolCode, controlPoints,
+                    scale, bbox, modifiers, attributes, format);
+
+                //DEBUGGING
+                if (ErrorLogger.getLevel().intValue() <= LogLevel.FINER.intValue()) {
+                    console.log("");
+                    let sb: string = "";
+                    sb += ("\nID: " + id + "\n");
+                    sb += ("Name: " + name + "\n");
+                    sb += ("Description: " + description + "\n");
+                    sb += ("SymbolID: " + symbolCode + "\n");
+                    sb += ("Scale: " + scale.toString() + "\n");
+                    sb += ("BBox: " + bbox + "\n");
+                    sb += ("Coords: " + controlPoints + "\n");
+                    sb += ("Modifiers: " + modifiers + "\n");
+                    ErrorLogger.LogMessage("WebRenderer", "RenderSymbol", sb.toString(), LogLevel.FINER);
+                }
+                if (ErrorLogger.getLevel().intValue() <= LogLevel.FINEST.intValue()) {
+                    let briefOutput: string = output.replaceAll("</Placemark>", "</Placemark>\n");
+                    briefOutput = output.replaceAll("(?s)<description[^>]*>.*?</description>", "<description></description>");
+                    ErrorLogger.LogMessage("WebRenderer", "RenderSymbol", "Output:\n" + briefOutput, LogLevel.FINEST);
+                }
             }
         
 
@@ -338,6 +350,78 @@ export class WebRenderer /* extends Applet */ {
         return output;
     }
 
+    /**
+     * Renders all 3d multi-point symbols, creating KML or GeoJSON that can be 
+     * used to draw it on a Google map.
+     * 3D version of {@link RenderSymbol()}
+     * @param id A unique identifier used to identify the symbol by Google map. 
+     * The id will be the folder name that contains the graphic.
+     * @param name a string used to display to the user as the name of the 
+     * graphic being created.
+     * @param description a brief description about the graphic being made and 
+     * what it represents.
+     * @param symbolCode A 20-30 digit symbolID corresponding to one of the
+     * graphics in the MIL-STD-2525D
+     * @param controlPoints The 2D vertices of the graphics that make up the
+     * graphic.  Passed in the format of a string, using decimal degrees 
+     * separating lat and lon by a comma, separating coordinates by a space.  
+     * The following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
+     * @param altitudeMode Indicates whether the symbol should interpret 
+     * altitudes as above sea level or above ground level. Options are 
+     * "clampToGround", "relativeToGround" (from surface of earth), "absolute" 
+     * (sea level), "relativeToSeaFloor" (from the bottom of major bodies of 
+     * water).
+     * @param scale A number corresponding to how many meters one meter of our 
+     * map represents. A value "50000" would mean 1:50K which means for every 
+     * meter of our map it represents 50000 meters of real world distance.
+     * @param bbox The viewable area of the map.  Passed in the format of a
+     * string "lowerLeftX,lowerLeftY,upperRightX,upperRightY." Not required
+     * but can speed up rendering in some cases.
+     * example: "-50.4,23.6,-42.2,24.2"
+     * @param modifiers {@link Map}, keyed using constants from Modifiers.
+     * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
+     * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
+     * @param format An enumeration: 2 for GeoJSON.
+     * @return A JSON string representation of the graphic.
+     */
+    public static RenderMilStd3dSymbol(id: string, name: string, description: string,
+        symbolCode: string, controlPoints: string, altitudeMode: string,
+        scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>, format: int): string {
+        let output: string = "";
+        try {
+            output = Shape3DHandler.RenderMilStd3dSymbol(id, name, description, symbolCode, controlPoints, altitudeMode,
+                scale, bbox, modifiers, attributes, format);
+
+            //DEBUGGING
+            if (ErrorLogger.getLevel().intValue() <= LogLevel.FINER.intValue()) {
+                console.log("");
+                let sb: string = "";
+                sb += ("\nID: " + id + "\n");
+                sb += ("Name: " + name + "\n");
+                sb += ("Description: " + description + "\n");
+                sb += ("SymbolID: " + symbolCode + "\n");
+                sb += ("Scale: " + scale.toString() + "\n");
+                sb += ("BBox: " + bbox + "\n");
+                sb += ("Coords: " + controlPoints + "\n");
+                sb += ("Modifiers: " + modifiers + "\n");
+                ErrorLogger.LogMessage("WebRenderer", "RenderMilStd3dSymbol", sb.toString(), LogLevel.FINER);
+            }
+            if (ErrorLogger.getLevel().intValue() <= LogLevel.FINEST.intValue()) {
+                let briefOutput: string = output.replaceAll("</Placemark>", "</Placemark>\n");
+                briefOutput = output.replaceAll("(?s)<description[^>]*>.*?</description>", "<description></description>");
+                ErrorLogger.LogMessage("WebRenderer", "RenderMilStd3dSymbol", "Output:\n" + briefOutput, LogLevel.FINEST);
+            }
+        } catch (ea) {
+            if (ea instanceof Error) {
+                output = "{\"type\":'error',error:'There was an error creating the 3D MilStdSymbol - " + ea.toString() + "'}";
+                ErrorLogger.LogException("WebRenderer", "RenderMilStd3dSymbol", ea, LogLevel.WARNING);
+            } else {
+                throw ea;
+            }
+        }
+
+        return output;
+    }
 
     /**
      * Renders all MilStd 2525 multi-point symbols, creating MilStdSymbol that contains the

--- a/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
@@ -642,6 +642,25 @@ export class WebRenderer /* extends Applet */ {
         return output;
     }
 
+    public static RenderBasic3DShape(id: string, name: string, description: string,
+        basicShapeType: int, controlPoints: string, altitudeMode: string,
+        scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>, format: int): string {
+        let output: string = "";
+        try {
+            output = Shape3DHandler.RenderBasic3DShape(id, name, description, basicShapeType, controlPoints, altitudeMode,
+                scale, bbox, modifiers, attributes, format);
+        } catch (ea) {
+            if (ea instanceof Error) {
+                output = "{\"type\":'error',error:'There was an error creating the 3D MilStdSymbol - " + ea.toString() + "'}";
+                ErrorLogger.LogException("WebRenderer", "RenderBasic3DShape", ea, LogLevel.WARNING);
+            } else {
+                throw ea;
+            }
+        }
+
+        return output;
+    }
+
     /**
      * Given a symbol code meant for a single point symbol, returns the
      * anchor point at which to display that image based off the image returned

--- a/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
@@ -25,6 +25,7 @@ import { mdlGeodesic } from "../../JavaTacticalRenderer/mdlGeodesic"
 import { POINT2 } from "../../JavaLineArray/POINT2";
 import { ref } from "../../JavaLineArray/ref"
 import { BasicShapes } from "../../JavaLineArray/BasicShapes";
+import { Basic3DShapes } from "./utilities/Basic3DShapes";
 import { Shape3DHandler } from "./Shape3DHandler";
 
 
@@ -204,7 +205,7 @@ export class WebRenderer /* extends Applet */ {
 
 
     /**
-     * Renders all multi-point symbols, creating KML that can be used to draw
+     * Renders all multi-point symbols, creating KML, GeoJSON or SVG that can be used to draw
      * it on a Google map.  Multipoint symbols cannot be draw the same 
      * at different scales. For instance, graphics with arrow heads will need to 
      * redraw arrowheads when you zoom in on it.  Similarly, graphics like a 
@@ -239,8 +240,8 @@ export class WebRenderer /* extends Applet */ {
      * @param modifiers {@link Map}, keyed using constants from Modifiers.
      * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
      * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
-     * @param format An enumeration: 2 for GeoJSON.
-     * @return A JSON string representation of the graphic.
+     * @param format {@link OUTPUT_FORMAT_KML}, {@link OUTPUT_FORMAT_GEOJSON} or {@link OUTPUT_FORMAT_GEOSVG}
+     * @return A KML, GeoJSON or SVG string representation of the graphic.
      */
     public static RenderSymbol(id: string, name: string, description: string,
         symbolCode: string, controlPoints: string, altitudeMode: string,
@@ -302,7 +303,7 @@ export class WebRenderer /* extends Applet */ {
 
 
     /**
-     * Renders all multi-point symbols, creating KML or JSON for the user to
+     * Renders all multi-point symbols, creating KML, GeoJSON or SVG for the user to
      * parse and render as they like.
      * This function requires the bounding box to help calculate the new
      * locations.
@@ -326,8 +327,8 @@ export class WebRenderer /* extends Applet */ {
      * @param modifiers {@link Map}, keyed using constants from Modifiers.
      * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
      * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
-     * @param format An enumeration: 2 for GeoJSON.
-     * @return A JSON (1) or KML (0) string representation of the graphic.
+     * @param format {@link OUTPUT_FORMAT_KML}, {@link OUTPUT_FORMAT_GEOJSON} or {@link OUTPUT_FORMAT_GEOSVG}
+     * @return A KML, GeoJSON or SVG string representation of the graphic.
      */
     public static RenderSymbol2D(id: string, name: string, description: string, symbolCode: string, controlPoints: string,
         pixelWidth: int, pixelHeight: int, bbox: string, modifiers: Map<string, string>,
@@ -378,8 +379,8 @@ export class WebRenderer /* extends Applet */ {
      * @param modifiers {@link Map}, keyed using constants from Modifiers.
      * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
      * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
-     * @param format An enumeration: 2 for GeoJSON.
-     * @return A JSON string representation of the graphic.
+     * @param format {@link OUTPUT_FORMAT_KML} or {@link OUTPUT_FORMAT_GEOJSON}
+     * @return A KML or GeoJSON string representation of the graphic.
      */
     public static RenderMilStd3dSymbol(id: string, name: string, description: string,
         symbolCode: string, controlPoints: string, altitudeMode: string,
@@ -447,11 +448,7 @@ export class WebRenderer /* extends Applet */ {
      *            lat and lon by a comma, separating coordinates by a space. The
      *            following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
      * @param altitudeMode
-     *            Indicates whether the symbol should interpret altitudes as
-     *            above sea level or above ground level. Options are
-     *            "clampToGround", "relativeToGround" (from surface of earth),
-     *            "absolute" (sea level), "relativeToSeaFloor" (from the bottom
-     *            of major bodies of water).
+     *            ignored
      * @param scale
      *            A number corresponding to how many meters one meter of our map
      *            represents. A value "50000" would mean 1:50K which means for
@@ -509,9 +506,6 @@ export class WebRenderer /* extends Applet */ {
     }
 
     /**
-     * Renders all MilStd 2525 multi-point symbols, creating MilStdSymbol that contains the
-     * information needed to draw the symbol on the map.
-     * DOES NOT support RADARC, CAKE, TRACK etc...
      * ArrayList&lt;Point2D&gt; milStdSymbol.getSymbolShapes[index].getPolylines()
      * and 
      * ShapeInfo = milStdSymbol.getModifierShapes[index]. 
@@ -534,11 +528,7 @@ export class WebRenderer /* extends Applet */ {
      *            lat and lon by a comma, separating coordinates by a space. The
      *            following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
      * @param altitudeMode
-     *            Indicates whether the symbol should interpret altitudes as
-     *            above sea level or above ground level. Options are
-     *            "clampToGround", "relativeToGround" (from surface of earth),
-     *            "absolute" (sea level), "relativeToSeaFloor" (from the bottom
-     *            of major bodies of water).
+     *            Ignored
      * @param scale
      *            A number corresponding to how many meters one meter of our map
      *            represents. A value "50000" would mean 1:50K which means for
@@ -571,7 +561,7 @@ export class WebRenderer /* extends Applet */ {
         } catch (ea) {
             if (ea instanceof Error) {
                 mSymbol = null;
-                ErrorLogger.LogException("WebRenderer", "RenderMultiPointAsMilStdSymbol" + " - " + basicShapeType, ea, LogLevel.WARNING);
+                ErrorLogger.LogException("WebRenderer", "RenderBasicShapeAsMilStdSymbol" + " - " + basicShapeType, ea, LogLevel.WARNING);
             } else {
                 throw ea;
             }
@@ -580,15 +570,9 @@ export class WebRenderer /* extends Applet */ {
         return mSymbol;
     }
 
-        /**
-     * Renders all multi-point symbols, creating KML that can be used to draw
-     * it on a Google map.  Multipoint symbols cannot be draw the same 
-     * at different scales. For instance, graphics with arrow heads will need to 
-     * redraw arrowheads when you zoom in on it.  Similarly, graphics like a 
-     * Forward Line of Troops drawn with half circles can improve performance if 
-     * clipped when the parts of the graphic that aren't on the screen.  To help 
-     * readjust graphics and increase performance, this function requires the 
-     * scale and bounding box to help calculate the new locations.
+    /**
+     * Renders basic shapes, creating KML, GeoJSON or SVG that can be used to draw
+     * it on a Google map.
      * @param id A unique identifier used to identify the symbol by Google map. 
      * The id will be the folder name that contains the graphic.
      * @param name a string used to display to the user as the name of the 
@@ -596,6 +580,54 @@ export class WebRenderer /* extends Applet */ {
      * @param description a brief description about the graphic being made and 
      * what it represents.
      * @param basicShapeType {@link BasicShapes}
+     * @param controlPoints The vertices of the graphics that make up the
+     * graphic.  Passed in the format of a string, using decimal degrees 
+     * separating lat and lon by a comma, separating coordinates by a space.  
+     * The following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
+     * @param altitudeMode ignored
+     * @param scale A number corresponding to how many meters one meter of our 
+     * map represents. A value "50000" would mean 1:50K which means for every 
+     * meter of our map it represents 50000 meters of real world distance.
+     * @param bbox The viewable area of the map.  Passed in the format of a
+     * string "lowerLeftX,lowerLeftY,upperRightX,upperRightY." Not required
+     * but can speed up rendering in some cases.
+     * example: "-50.4,23.6,-42.2,24.2"
+     * @param modifiers {@link Map}, keyed using constants from Modifiers.
+     * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
+     * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
+     * @param format {@link OUTPUT_FORMAT_KML}, {@link OUTPUT_FORMAT_GEOJSON} or {@link OUTPUT_FORMAT_GEOSVG}
+     * @return A KML, GeoJSON or SVG string representation of the graphic.
+     */
+    public static RenderBasicShape(id: string, name: string, description: string,
+        basicShapeType: int, controlPoints: string, altitudeMode: string,
+        scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>, format: int): string {
+        let output: string = "";
+        try {
+            if (SymbolUtilities.isBasicShape(basicShapeType))
+                output = MultiPointHandler.RenderBasicShape(id, name, description, basicShapeType, controlPoints,
+                    scale, bbox, modifiers, attributes, format);
+        } catch (ea) {
+            if (ea instanceof Error) {
+                output = "{\"type\":'error',error:'There was an error creating the MilStdSymbol - " + ea.toString() + "'}";
+                ErrorLogger.LogException("WebRenderer", "RenderBasicShape", ea, LogLevel.WARNING);
+            } else {
+                throw ea;
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Renders basic 3D shapes, creating KML or GeoJSON that can be used to draw
+     * it on a Google map.
+     * @param id A unique identifier used to identify the symbol by Google map. 
+     * The id will be the folder name that contains the graphic.
+     * @param name a string used to display to the user as the name of the 
+     * graphic being created.
+     * @param description a brief description about the graphic being made and 
+     * what it represents.
+     * @param basicShapeType {@link Basic3DShapes}
      * @param controlPoints The vertices of the graphics that make up the
      * graphic.  Passed in the format of a string, using decimal degrees 
      * separating lat and lon by a comma, separating coordinates by a space.  
@@ -615,30 +647,9 @@ export class WebRenderer /* extends Applet */ {
      * @param modifiers {@link Map}, keyed using constants from Modifiers.
      * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
      * @param attributes {@link Map}, keyed using constants from MilStdAttributes.
-     * @param format An enumeration: 2 for GeoJSON.
-     * @return A JSON string representation of the graphic.
+     * @param format {@link OUTPUT_FORMAT_KML}, {@link OUTPUT_FORMAT_GEOJSON}
+     * @return A KML or GeoJSON string representation of the graphic.
      */
-    public static RenderBasicShape(id: string, name: string, description: string,
-        basicShapeType: int, controlPoints: string, altitudeMode: string,
-        scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>, format: int): string {
-        let output: string = "";
-        try {
-            JavaRendererUtilities.addAltModeToModifiersString(attributes, altitudeMode);
-            if (SymbolUtilities.isBasicShape(basicShapeType))
-                output = MultiPointHandler.RenderBasicShape(id, name, description, basicShapeType, controlPoints,
-                    scale, bbox, modifiers, attributes, format);
-        } catch (ea) {
-            if (ea instanceof Error) {
-                output = "{\"type\":'error',error:'There was an error creating the MilStdSymbol - " + ea.toString() + "'}";
-                ErrorLogger.LogException("WebRenderer", "RenderBasicShape", ea, LogLevel.WARNING);
-            } else {
-                throw ea;
-            }
-        }
-
-        return output;
-    }
-
     public static RenderBasic3DShape(id: string, name: string, description: string,
         basicShapeType: int, controlPoints: string, altitudeMode: string,
         scale: double, bbox: string, modifiers: Map<string, string>, attributes: Map<string, string>, format: int): string {

--- a/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts
@@ -254,9 +254,6 @@ export class WebRenderer /* extends Applet */ {
                 && (format === WebRenderer.OUTPUT_FORMAT_KML || format === WebRenderer.OUTPUT_FORMAT_GEOJSON)
                 && JavaRendererUtilities.is3dSymbol(symbolCode)
                 && modifiers.get(Modifiers.X_ALTITUDE_DEPTH)) {
-                if (!(altitudeMode))
-                    altitudeMode = "absolute";
-
                 output = this.RenderMilStd3dSymbol(id, name, description, symbolCode, controlPoints, altitudeMode, scale, bbox, modifiers, attributes, format);
             }
 

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -1,21 +1,67 @@
-import { BasicShapes } from "../../../JavaLineArray/BasicShapes";
 import { TacticalLines } from "../../../JavaLineArray/TacticalLines";
+import { Modifiers } from "../../../renderer/utilities/Modifiers";
 
 export class Basic3DShapes {
 
-    public static readonly CYLINDER = BasicShapes.CIRCLE;
+    /**
+     * Anchor Points: This shape requires one anchor point
+     * 
+     * Modifiers: radius ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     *
+     * @see DrawRules.CIRCULAR1
+     */
+    public static readonly CYLINDER = TacticalLines.PBS_CIRCLE;
 
+    /**
+     * Anchor Points: This shape requires two anchor points
+     * 
+     * Modifiers: width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
     public static readonly ORBIT = TacticalLines.BS_ORBIT;
 
+    /**
+     * Anchor Points: This shape requires at least two anchor points
+     * 
+     * Modifiers: width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
     public static readonly ROUTE = TacticalLines.BS_3D_ROUTE;
 
-    public static readonly POLYGON = BasicShapes.AREA;
+    /**
+     * Anchor Points: This shape requires at least three anchor points
+     * 
+     * Modifiers: min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
+    public static readonly POLYGON = TacticalLines.BS_AREA;
 
+    /**
+     * Anchor Points: This shape requires one anchor point
+     * 
+     * Modifiers: min radius and max radius ({@link Modifiers.AM_DISTANCE}), left and right azimuth ({@link Modifiers.AN_AZIMUTH}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
     public static readonly RADARC = TacticalLines.BS_3D_RADARC;
 
+    /**
+     * Anchor Points: This shape requires at least three anchor points
+     * 
+     * Modifiers: radius ({@link Modifiers.AM_DISTANCE}), left and right azimuth ({@link Modifiers.AN_AZIMUTH}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
     public static readonly POLYARC = TacticalLines.BS_POLYARC;
 
+    /** 
+     * A collection of radarcs
+     * 
+     * Anchor Points: This shape requires one anchor point
+     * 
+     * Modifiers (for each radarc): min radius and max radius ({@link Modifiers.AM_DISTANCE}), left and right azimuth ({@link Modifiers.AN_AZIMUTH}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
     public static readonly CAKE = TacticalLines.BS_3D_CAKE;
 
+    /**
+     * A collection of routes
+     * 
+     * Anchor Points: This shape requires at least two anchor points
+     * 
+     * Modifiers (for each segment): width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     */
     public static readonly TRACK = TacticalLines.BS_3D_TRACK;
 }

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -1,4 +1,5 @@
 import { BasicShapes } from "../../../JavaLineArray/BasicShapes";
+import { TacticalLines } from "../../../JavaLineArray/TacticalLines";
 
 export class Basic3DShapes {
 
@@ -6,7 +7,7 @@ export class Basic3DShapes {
 
     public static readonly ORBIT: never; // TODO
 
-    public static readonly ROUTE: never; // TODO
+    public static readonly ROUTE = TacticalLines.BS_3D_ROUTE;
 
     public static readonly POLYGON = BasicShapes.AREA;
 
@@ -16,5 +17,5 @@ export class Basic3DShapes {
 
     public static readonly CAKE: never; // TODO
 
-    public static readonly TRACK: never; // TODO
+    public static readonly TRACK = TacticalLines.BS_3D_TRACK;
 }

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -13,7 +13,7 @@ export class Basic3DShapes {
 
     public static readonly RADARC = TacticalLines.BS_3D_RADARC;
 
-    public static readonly POLYARC: never; // TODO
+    public static readonly POLYARC = TacticalLines.BS_POLYARC;
 
     public static readonly CAKE = TacticalLines.BS_3D_CAKE;
 

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -24,7 +24,7 @@ export class Basic3DShapes {
      * 
      * Modifiers: width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
      */
-    public static readonly ROUTE = TacticalLines.BS_3D_ROUTE;
+    public static readonly ROUTE = TacticalLines.BS_ROUTE;
 
     /**
      * Anchor Points: This shape requires at least three anchor points
@@ -38,7 +38,7 @@ export class Basic3DShapes {
      * 
      * Modifiers: min radius and max radius ({@link Modifiers.AM_DISTANCE}), left and right azimuth ({@link Modifiers.AN_AZIMUTH}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
      */
-    public static readonly RADARC = TacticalLines.BS_3D_RADARC;
+    public static readonly RADARC = TacticalLines.BS_RADARC;
 
     /**
      * Anchor Points: This shape requires at least three anchor points
@@ -54,7 +54,7 @@ export class Basic3DShapes {
      * 
      * Modifiers (for each radarc): min radius and max radius ({@link Modifiers.AM_DISTANCE}), left and right azimuth ({@link Modifiers.AN_AZIMUTH}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
      */
-    public static readonly CAKE = TacticalLines.BS_3D_CAKE;
+    public static readonly CAKE = TacticalLines.BS_CAKE;
 
     /**
      * A collection of routes
@@ -63,5 +63,5 @@ export class Basic3DShapes {
      * 
      * Modifiers (for each segment): left and right width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
      */
-    public static readonly TRACK = TacticalLines.BS_3D_TRACK;
+    public static readonly TRACK = TacticalLines.BS_TRACK;
 }

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -11,11 +11,11 @@ export class Basic3DShapes {
 
     public static readonly POLYGON = BasicShapes.AREA;
 
-    public static readonly RADARC: never; // TODO
+    public static readonly RADARC = TacticalLines.BS_3D_RADARC;
 
     public static readonly POLYARC: never; // TODO
 
-    public static readonly CAKE: never; // TODO
+    public static readonly CAKE = TacticalLines.BS_3D_CAKE;
 
     public static readonly TRACK = TacticalLines.BS_3D_TRACK;
 }

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -61,7 +61,7 @@ export class Basic3DShapes {
      * 
      * Anchor Points: This shape requires at least two anchor points
      * 
-     * Modifiers (for each segment): width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
+     * Modifiers (for each segment): left and right width ({@link Modifiers.AM_DISTANCE}), and min and max altitude ({@link Modifiers.X_ALTITUDE_DEPTH}).
      */
     public static readonly TRACK = TacticalLines.BS_3D_TRACK;
 }

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -5,7 +5,7 @@ export class Basic3DShapes {
 
     public static readonly CYLINDER = BasicShapes.CIRCLE;
 
-    public static readonly ORBIT: never; // TODO
+    public static readonly ORBIT = TacticalLines.BS_ORBIT;
 
     public static readonly ROUTE = TacticalLines.BS_3D_ROUTE;
 

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts
@@ -1,0 +1,20 @@
+import { BasicShapes } from "../../../JavaLineArray/BasicShapes";
+
+export class Basic3DShapes {
+
+    public static readonly CYLINDER = BasicShapes.CIRCLE;
+
+    public static readonly ORBIT: never; // TODO
+
+    public static readonly ROUTE: never; // TODO
+
+    public static readonly POLYGON = BasicShapes.AREA;
+
+    public static readonly RADARC: never; // TODO
+
+    public static readonly POLYARC: never; // TODO
+
+    public static readonly CAKE: never; // TODO
+
+    public static readonly TRACK: never; // TODO
+}

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/JavaRendererUtilities.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/JavaRendererUtilities.ts
@@ -1,7 +1,9 @@
 import { type int, type double } from "../../../graphics2d/BasicTypes";
 import { Point2D } from "../../../graphics2d/Point2D";
+import { DrawRules } from "../../../renderer/utilities/DrawRules";
 import { MilStdAttributes } from "../../../renderer/utilities/MilStdAttributes";
 import { Modifiers } from "../../../renderer/utilities/Modifiers";
+import { MSLookup } from "../../../renderer/utilities/MSLookup";
 
 /**
  *
@@ -276,61 +278,15 @@ export class JavaRendererUtilities {
 
     }//*/
 
-    /**
-     * Checks symbolID and if the relevant modifiers are present
-     *
-     * @param symbolCode
-     * @param modifiers
-     * @return
-     * @deprecated
-     */
-    public static is3dSymbol(symbolCode: string, modifiers: Map<string, string>): boolean {
-        let returnValue: boolean = false;
-
+    public static is3dSymbol(symbolCode: string): boolean {
         try {
-            let symbolId: string = symbolCode.substring(4, 10);
-
-            if (symbolId === "ACAI--" || // Airspace Coordination Area Irregular
-                symbolId === "ACAR--" || // Airspace Coordination Area Rectangular
-                symbolId === "ACAC--" || // Airspace Coordination Area Circular
-                symbolId === "AKPC--" || // Kill box circular
-                symbolId === "AKPR--" || // Kill box rectangular
-                symbolId === "AKPI--" || // Kill box irregular
-                symbolId === "ALC---" || // Air corridor
-                symbolId === "ALM---" || // 
-                symbolId === "ALS---" || // SAAFR
-                symbolId === "ALU---" || // UAV
-                symbolId === "ALL---" || // Low level transit route
-                symbolId === "AAR---"
-                || symbolId === "AAF---"
-                || symbolId === "AAH---"
-                || symbolId === "AAM---" || // MEZ
-                symbolId === "AAML--" || // LOMEZ
-                symbolId === "AAMH--") {
-
-                try {
-                    if (modifiers != null) {
-
-                        // These guys store array values.  Put in appropriate data strucutre
-                        // for MilStdSymbol.
-                        if (modifiers.has(Modifiers.X_ALTITUDE_DEPTH)) {
-                            let altitudes: string[] = modifiers.get(Modifiers.X_ALTITUDE_DEPTH).split(",");
-                            if (altitudes.length < 2) {
-                                returnValue = false;
-                            } else {
-                                returnValue = true;
-                            }
-                        }
-
-                    }
-                } catch (exc) {
-                    if (exc instanceof Error) {
-                        console.error(exc.message);
-                    } else {
-                        throw exc;
-                    }
-                }
-            }
+            let msi = MSLookup.getInstance().getMSLInfo(symbolCode);
+            let drawRule = msi.getDrawRule();
+            return drawRule === DrawRules.AREA1
+                || drawRule === DrawRules.AREA10
+                || drawRule === DrawRules.RECTANGULAR1
+                || drawRule === DrawRules.CIRCULAR1
+                || drawRule === DrawRules.CORRIDOR1;
         } catch (e) {
             if (e instanceof Error) {
                 console.error(e.message);
@@ -338,7 +294,7 @@ export class JavaRendererUtilities {
                 throw e;
             }
         }
-        return returnValue;
+        return false;
     }
 
     /**

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/Point3D.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/Point3D.ts
@@ -1,0 +1,40 @@
+import { type double } from "../../../graphics2d/BasicTypes";
+import { Point2D } from "../../../graphics2d/Point2D";
+
+export class Point3D extends Point2D {
+    public z: double;
+
+    public constructor(pt: Point2D, z: double);
+    public constructor(x: double, y: double, z: double);
+    public constructor(...args: unknown[]) {
+
+        switch (args.length) {
+            case 0: {
+                super();
+                break;
+            }
+
+            case 2: {
+                const [pt, z] = args as [Point2D, double];
+                super(pt.x, pt.y);
+                this.z = z;
+                break;
+            }
+
+            case 3: {
+                const [x, y, z] = args as [double, double, double];
+                super(x, y);
+                this.z = z;
+                break;
+            }
+
+            default: {
+                throw Error(`Invalid number of arguments`);
+            }
+        }
+    }
+
+    public getZ(): double {
+        return this.z;
+    }
+}

--- a/src/main/ts/armyc2/c5isr/web/render/utilities/ShapeInfo3D.ts
+++ b/src/main/ts/armyc2/c5isr/web/render/utilities/ShapeInfo3D.ts
@@ -1,0 +1,23 @@
+import { Point3D } from "./Point3D";
+import { ShapeInfo } from "../../../renderer/utilities/ShapeInfo";
+
+export class ShapeInfo3D extends ShapeInfo {
+    private _ModifierPosition3D: Point3D = null;
+    private _Polylines3D: Array<Array<Point3D>> = null;
+
+    public override setModifierPosition(value: Point3D): void {
+        this._ModifierPosition3D = value;
+    }
+
+    public override getModifierPosition(): Point3D {
+        return this._ModifierPosition3D;
+    }
+
+    public override getPolylines(): Array<Array<Point3D>> {
+        return this._Polylines3D;
+    }
+
+    public override setPolylines(value: Array<Array<Point3D>>): void {
+        this._Polylines3D = value;
+    }
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -25,6 +25,7 @@
         "src/main/ts/armyc2/c5isr/renderer/utilities/SVGSymbolInfo.ts",
         "src/main/ts/armyc2/c5isr/renderer/utilities/SymbolUtilities.ts",
         "src/main/ts/armyc2/c5isr/renderer/MilStdIconRenderer.ts",
+        "src/main/ts/armyc2/c5isr/web/render/utilities/Basic3DShapes.ts",
         "src/main/ts/armyc2/c5isr/web/render/WebRenderer.ts",
         "index.ts"],
     "out": "docs"


### PR DESCRIPTION
- Methods
  - `WebRenderer.RenderMilStd3dSymbol()` Renders `AREA1`, `AREA10`, `RECTANGULAR1`, `CIRCULAR1` and `CORRIDOR1` symbols as 3D shapes by rendering the 2D shape then converting all edges to 3D walls with a ceiling and floor
  - `WebRenderer.RenderBasic3DShape()` renders basic shapes listed in `Basic3DShapes`
  - `WebRenderer.RenderSymbol()` now calls `RenderMilStd3dSymbol()` when the following are true:
    - Altitude mode is not "clampToGround"
    - Output format is KML or GeoJSON
    - The symbol supports 3D
    - An altitude is included (X modifier)
- Default 3D colors
  - For symbols: `SymbolUtilities.getLineColorOfAffiliation()` and `SymbolUtilities.getFillColorOfAffiliation()`
  - For basic shapes: Black lines with white fill 
- `Shape3DHandler` class mimics `MultiPointHandler` but for 3D shapes
- Improves WebRenderer method documentation by clarifying output format options and noting when `altitudeMode` argument isn't referenced
- Adds `<ExtendedData>` tag to KML with `symbolID` and `wasClipped`
- TypeScript only changes:
  - adds `toString()` method to `LogLevel` to improve error output
  - `getModifier_AM_AN_X()` returns number instead of string to match Android and Java


Other ports
- https://github.com/missioncommand/mil-sym-android/tree/3d-multipoints
- https://github.com/missioncommand/mil-sym-java/tree/3d-multipoints